### PR TITLE
Change telegram failures to warn

### DIFF
--- a/main.js
+++ b/main.js
@@ -516,7 +516,7 @@ function send_telegram_to_provider (consumer_id, provider_id, telegram_id, token
 
 				if (error_1)
 				{
-					log ("err", "EVENT", true, {},
+					log ("warn", "EVENT", true, {},
 						"Telegram failed ! response = " +
 							String(response)	+
 						" body = "			+
@@ -534,7 +534,7 @@ function send_telegram (message)
 	{
 		if (error)
 		{
-			log ("err", "EVENT", true, {},
+			log ("warn", "EVENT", true, {},
 				"Telegram failed ! response = " +
 					String(response)	+
 				" body = "			+


### PR DESCRIPTION
If a log with level 'err' is generated, it is sent via Telegram. If the Telegram API fails, it goes on forever