### PR TITLE
Update provider access tests to use new APIs

### DIFF
--- a/test/access.py
+++ b/test/access.py
@@ -1,13 +1,7 @@
 from consent import provider_reg
+from add_org import add_organization
 import psycopg2
 import random, string
-
-org = { "name"      : "Testing",
-        "website"   : "example.com",
-        "city"      : "Bengaluru",
-        "state"     : "ka",
-        "country"   : "IN"
-        }
 
 name = { "title"        : "Mr.",
          "firstName"    : "Testing",
@@ -29,12 +23,14 @@ except psycopg2.DatabaseError as error:
 
 cursor = conn.cursor()
 
-def init():
+def init_provider():
+
+
+        org_id = add_organization("rbccps.org")
 
         # use abc.xyz@rbccps.org certificate as provider
-
-        r = provider_reg("abc.xyz@rbccps.org", '7529547992', name , org, csr)
         # do not assert, can already be approved
+        r = provider_reg("abc.xyz@rbccps.org", '7529547992', name , org_id, csr)
 
         try:
                 cursor.execute("update consent.role as rr set status = 'approved' from consent.users where " + " users.id = rr.user_id and users.email = 'abc.xyz@rbccps.org'")
@@ -44,14 +40,14 @@ def init():
         except psycopg2.DatabaseError as error:
                 return {}
 
-def change_role(email, role):
+def reset_role(email):
+# set all roles with this email as rejected
         
         try:
-                cursor.execute("update consent.role as rr set status = 'approved',role = '" + role +"' from consent.users where " + " users.id = rr.user_id and users.email = '" + email + "'")
+                cursor.execute("update consent.role as rr set status = 'rejected' from consent.users where users.id = rr.user_id and users.email = '" + email + "'")
                 conn.commit()
 
         except psycopg2.DatabaseError as error:
-            print(error)
             return False
         
         return True 

--- a/test/add_org.py
+++ b/test/add_org.py
@@ -16,11 +16,19 @@ cursor = conn.cursor()
 def add_organization(website):
 
         try:
-                cursor.execute("insert into consent.organizations (name,website,city,state,country,created_at,updated_at) values ('Testing Org', '" + website + "', 'testing-city', 'TA', 'TS', now(), now()) returning id")
+                cursor.execute("select id from consent.organizations where website = '" + website + "'")
                 conn.commit()
 
         except psycopg2.DatabaseError as error:
                 return {}
+ 
+        if cursor.rowcount == 0:
+                try:
+                        cursor.execute("insert into consent.organizations (name,website,city,state,country,created_at,updated_at) values ('Testing Org', '" + website + "', 'testing-city', 'TA', 'TS', now(), now()) returning id")
+                        conn.commit()
+
+                except psycopg2.DatabaseError as error:
+                        return {}
 
         oid = cursor.fetchone()[0]
         return oid

--- a/test/test-access.py
+++ b/test/test-access.py
@@ -1,18 +1,21 @@
 from init import untrusted
 from init import consumer
 from access import *
+from consent import role_reg
 
-init()
+init_provider()
 
 # use consumer certificate to register
 email   = "barun@iisc.ac.in"
-r       = provider_reg(email, '7529547992', name , org, csr)
+assert reset_role(email) == True
+org_id = add_organization("iisc.ac.in")
 
-# delete all old policies
+# delete all old policies using acl/set API
 policy = "x can access x"
 r = untrusted.set_policy(policy)
 assert r['success'] is True
 
+# provider ID of abc.xyz@rbccps.org
 provider_id = 'rbccps.org/f3dad987e514af08a4ac46cf4a41bd1df645c8cc'
 
 ##### consumer #####
@@ -24,8 +27,9 @@ body        = { "id"    : resource_id + "/someitem"}
 r = consumer.get_token(body)
 assert r['success']     is False
 
-r = change_role(email, 'consumer')
-assert r == True
+r = role_reg(email, '9454234223', name , ["consumer"], None, csr)
+assert r['success']     == True
+assert r['status_code'] == 200
 
 r = untrusted.provider_access(email, 'consumer', resource_id, 'resourcegroup')
 assert r['success']     == True
@@ -59,8 +63,9 @@ body = { "id"    : provider_id + "/catalogue.iudx.io/catalogue/crud" }
 r = consumer.get_token(body)
 assert r['success']     is False
 
-r = change_role(email, 'onboarder')
-assert r == True
+r = role_reg(email, '9454234223', name , ["onboarder"], org_id)
+assert r['success']     == True
+assert r['status_code'] == 200
 
 r = untrusted.provider_access(email, 'onboarder')
 assert r['success']     == True
@@ -83,8 +88,9 @@ body        = {"id" : resource_id + "/someitem", "api" : "/iudx/v1/adapter" }
 r = consumer.get_token(body)
 assert r['success']     is False
 
-r = change_role(email, 'data ingester')
-assert r == True
+r = role_reg(email, '9454234223', name , ["data ingester"], org_id)
+assert r['success']     == True
+assert r['status_code'] == 200
 
 # invalid resource type
 r = untrusted.provider_access(email, 'data ingester', resource_id, 'catalogue')
@@ -118,4 +124,3 @@ assert r['status_code'] == 403
 r = untrusted.provider_access(email, 'data ingester', '/aaaaa/sssss', 'resourcegroup')
 assert r['success']     == False
 assert r['status_code'] == 403
-


### PR DESCRIPTION
* test-access.py used SQL to update roles for a user. Now the registration API is used instead
* The `add_organization` function now returns organization ID if the organization exists