### PR TITLE
Bug fixes encountered during testing

### DIFF
--- a/main.js
+++ b/main.js
@@ -3948,7 +3948,7 @@ app.post("/auth/v[1-2]/admin/organizations", async (req, res) => {
 
 app.post("/consent/v[1-2]/provider/registration", async (req, res) => {
 
-	const email	= res.locals.body.email.toLowerCase();
+	let email	= res.locals.body.email;
 	const phone 	= res.locals.body.phone;
 	let org_id 	= res.locals.body.organization;
 	const name 	= res.locals.body.name;
@@ -3965,6 +3965,8 @@ app.post("/consent/v[1-2]/provider/registration", async (req, res) => {
 
 	if (! is_valid_email(email) || ! phone_regex.test(phone))
 		return END_ERROR (res, 403, "Invalid data (email/phone)");
+
+	email = email.toLowerCase();
 
 	if (! org_id)
 		return END_ERROR (res, 403, "Invalid data (organization)");
@@ -4078,7 +4080,7 @@ app.post("/consent/v[1-2]/provider/registration", async (req, res) => {
 
 app.post("/consent/v[1-2]/registration", async (req, res) => {
 
-	const email	= res.locals.body.email.toLowerCase();
+	let email	= res.locals.body.email;
 	const phone 	= res.locals.body.phone;
 	const name 	= res.locals.body.name;
 	const raw_csr	= res.locals.body.csr;
@@ -4096,6 +4098,8 @@ app.post("/consent/v[1-2]/registration", async (req, res) => {
 
 	if (! is_valid_email(email) || ! phone_regex.test(phone))
 		return END_ERROR (res, 403, "Invalid data (email/phone)");
+
+	email = email.toLowerCase();
 
 	if (! Array.isArray(roles) || roles.length === 0)
 		return END_ERROR (res, 403, "Invalid data (roles)");

--- a/main.js
+++ b/main.js
@@ -3843,8 +3843,8 @@ app.put("/auth/v[1-2]/admin/provider/registrations/status", (req, res) => {
 	}
 	let user, csr, org, role;
 	try {
-		user = pg.querySync("SELECT * FROM consent.users, consent.role "	+
-				    " WHERE consent.users.id = consent.role.user_id "	+
+		user = pg.querySync("SELECT users.*, role.role, role.status FROM consent.users, consent.role "	+
+				    " WHERE consent.users.id = consent.role.user_id AND role.role = 'provider'"	+
 				    " AND consent.users.id = $1::integer",[user_id])[0] || null;
 		csr = pg.querySync("SELECT * FROM consent.certificates WHERE user_id = $1::integer", [user_id])[0] || null;
 		org = pg.querySync("SELECT * FROM consent.organizations WHERE id = $1::integer", [user.organization_id])[0] || null;

--- a/main.js
+++ b/main.js
@@ -70,6 +70,7 @@ const MIN_TOKEN_HASH_LEN	= 64;
 const MAX_TOKEN_HASH_LEN	= 64;
 
 const MAX_SAFE_STRING_LEN	= 512;
+const PG_MAX_INT		= 2147483647;
 
 /* for access API */
 const ACCESS_ROLES		= ["consumer", "data ingester", "onboarder"];
@@ -3973,7 +3974,7 @@ app.post("/consent/v[1-2]/provider/registration", async (req, res) => {
 
 	org_id = parseInt(org_id, 10);
 
-	if (isNaN(org_id) || org_id < 1)
+	if (isNaN(org_id) || org_id < 1 || org_id > PG_MAX_INT)
 		return END_ERROR (res, 403, "Invalid data (organization)");
 
 	try
@@ -4119,7 +4120,7 @@ app.post("/consent/v[1-2]/registration", async (req, res) => {
 
 		org_id = parseInt(org_id, 10);
 
-		if (isNaN(org_id) || org_id < 1)
+		if (isNaN(org_id) || org_id < 1 || org_id > PG_MAX_INT)
 			return END_ERROR (res, 403, "Invalid data (organization)");
 
 		// check if org registered

--- a/main.js
+++ b/main.js
@@ -4088,13 +4088,13 @@ app.post("/consent/v[1-2]/registration", async (req, res) => {
 	let email	= res.locals.body.email;
 	const phone 	= res.locals.body.phone;
 	const name 	= res.locals.body.name;
-	const raw_csr	= res.locals.body.csr;
+	let raw_csr	= res.locals.body.csr;
 	let org_id 	= res.locals.body.organization;
 	let roles	= res.locals.body.roles;
 
 	let user_id, signed_cert = null;
-	let check_orgid;
-	var existing_user = false;
+	let check_orgid = false;
+	var existing_user = false, certless_user = false;
 
 	const phone_regex = new RegExp(/^[9876]\d{9}$/);
 
@@ -4167,7 +4167,36 @@ app.post("/consent/v[1-2]/registration", async (req, res) => {
 		{
 			existing_user = true;
 			user_id = check_uid.rows[0].id;
+
+			/* if registered as consumer first, org_id will be undefined */
 			check_orgid = check_uid.rows[0].organization_id;
+
+			/* check if cert field for user is null (rejected/pending
+			 * provider). If yes, use the existing CSR to create the certificate */
+			const check = await pool.query (
+				"SELECT * FROM consent.certificates"		+
+				" WHERE certificates.user_id = $1::integer"	+
+				" AND cert IS NULL",
+				[ user_id ]);
+
+			if (check.rows.length !== 0)
+			{
+				raw_csr 	= check.rows[0].csr;
+				certless_user 	= true;
+			}
+
+			/* check if user is trying to register for role
+			 * that they are already registered for */
+			for (const val of roles)
+			{
+				let uid = null;
+
+				try { uid = await check_privilege(email, val); }
+				catch(error) { /* do nothing if role not there */ }
+
+				if (uid !== null)
+					return END_ERROR (res, 403, "Already registered as " + val);
+			}
 		}
 	}
 	catch(error)
@@ -4175,20 +4204,7 @@ app.post("/consent/v[1-2]/registration", async (req, res) => {
 		return END_ERROR (res, 500, "Internal error!", error);
 	}
 
-	if (existing_user)
-	{
-		for (const val of roles)
-		{
-			let uid = null;
-
-			try { uid = await check_privilege(email, val); }
-			catch(error) { /* do nothing if role not there */ }
-
-			if (uid !== null)
-				return END_ERROR (res, 403, "Already registered as " + val);
-		}
-	}
-	else	// create user
+	if (! existing_user || certless_user)	// generate certificate
 	{
 		if (! raw_csr || raw_csr.length > CSR_SIZE)
 			return END_ERROR (res, 400, "Invalid data (csr)");
@@ -4211,7 +4227,10 @@ app.post("/consent/v[1-2]/registration", async (req, res) => {
 		} catch (e) {
 			return END_ERROR(res, 500, "Certificate Error", e.message);
 		}
+	}
 
+	if (! existing_user)
+	{
 		try {
 			const user = await pool.query (
 				" INSERT INTO consent.users "			+
@@ -4250,7 +4269,23 @@ app.post("/consent/v[1-2]/registration", async (req, res) => {
 		}
 	}
 
-	// update org_id if the user was originally a consumer
+	if (certless_user) // update with certificate
+	{
+		try {
+			const cert = await pool.query (
+				"UPDATE consent.certificates SET "	+
+				" cert = $1::text, updated_at = NOW() " +
+				" WHERE user_id = $2::integer",
+				[ signed_cert, user_id ]);
+		}
+		catch(error)
+		{
+			return END_ERROR (res, 500, "Internal error!", error);
+		}
+	}
+
+	/* update org_id if the user was originally a consumer
+	 * (org_id would be null) */
 	if (check_orgid === undefined)
 	{
 		try

--- a/test/test-access.py
+++ b/test/test-access.py
@@ -37,13 +37,13 @@ assert r['status_code'] == 200
 # No capabilities
 r = untrusted.provider_access(email, 'consumer', resource_id, 'resourcegroup')
 assert r['success']     == False
-assert r['status_code'] == 403
+assert r['status_code'] == 400
 
 # Invalid capabilities
 caps = ["hello", "world"]
 r = untrusted.provider_access(email, 'consumer', resource_id, 'resourcegroup', caps)
 assert r['success']     == False
-assert r['status_code'] == 403
+assert r['status_code'] == 400
 
 caps = ['temporal'];
 r = untrusted.provider_access(email, 'consumer', resource_id, 'resourcegroup', caps)
@@ -127,7 +127,7 @@ assert r['status_code'] == 403
 # user does not exist
 r = untrusted.provider_access(email, 'onboarder', resource_id, 'resourcegroup')
 assert r['success']     == False
-assert r['status_code'] == 404
+assert r['status_code'] == 403
 
 ##### onboarder #####
 
@@ -171,7 +171,7 @@ assert r['status_code'] == 200
 # invalid resource type
 r = untrusted.provider_access(email, 'data ingester', resource_id, 'catalogue')
 assert r['success']     == False
-assert r['status_code'] == 403
+assert r['status_code'] == 400
 
 r = untrusted.provider_access(email, 'data ingester', resource_id, 'resourcegroup')
 assert r['success']     == True
@@ -195,8 +195,8 @@ assert r['success']     is True
 # invalid resource ID
 r = untrusted.provider_access(email, 'data ingester', '/aaaaa/sssss/sada/', 'resourcegroup')
 assert r['success']     == False
-assert r['status_code'] == 403
+assert r['status_code'] == 400
 
 r = untrusted.provider_access(email, 'data ingester', '/aaaaa/sssss', 'resourcegroup')
 assert r['success']     == False
-assert r['status_code'] == 403
+assert r['status_code'] == 400

--- a/test/test-consent.py
+++ b/test/test-consent.py
@@ -6,7 +6,7 @@ import string
 # invalid inputs
 r = provider_reg('a', 'b', 'c', 'd', 'e')
 assert r['success']     == False
-assert r['status_code'] == 403
+assert r['status_code'] == 400
 
 name = { "title"        : "mr.",
          "firstName"    : "abc",
@@ -25,19 +25,19 @@ email = ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in r
 # invalid phone
 r = provider_reg(email, '780w021-', name , org_id, csr)
 assert r['success']     == False
-assert r['status_code'] == 403
+assert r['status_code'] == 400
 
 # invalid csr
 bad_csr = "-----BEGIN CERTIFICATE REQUEST-----\nMIICjDCCAXQCAQAwRzELMAkGA1UEBhMCVVMxCzAJBgNVBAgMAkNBMRQwEgYDVQQK\nDAtNeU9yZywgSW5jLjEVMBMGA1UEAwwMbXlkb21haW4uY29tMIIBIjANBgkqhkiG\n9w0BAQEFAAOCAQ8AMIIBCgKCAQEAyhF2a5PeL72zGdL47/6zVQQQtZJcO01iVbjR\nSSyswUa2jcfYfoQEVKo1JAz25G3nYfSW1Te3OWjuihvPhZeatFSUwTxcZJFxzIWm\n4/gOQIhJKCA/Wry3liW2sjIGLuHxeH2BoQCIEZyYcqVpRWEJ9RusRFcwPgvROigh\nhMXhgE86uaIRs0yPqzhc7sl53T4qx6qvQJ6uTXBWBvUELgSSgeyaT0gwU1mGmPck\n7Svo6tsWfBFfgT5Ecbqsc2nqChAExgocp5tkPJYcy8FB/tU/FW0rFthqecSvMrpS\ncZW9+iyzseyPrcK9ka6XSlVu9EoX82RW7SRyRL2T5VN3JemXfQIDAQABoAAwDQYJ\nKoZIhvcNAQELBQADggEBAJRFEYn6dSzEYpgYLItUm7Sp3LzquJw7QfMyUvsy45rp\n0VTdQdYp/hVR2aCLiD33ht4FxlhbZm/8XcTuYolP6AbF6FldxWmmFFS9LRAj7nTV\ndU1pZftwFPp6JsKUCYHVsuxs7swliXbEcBVtD6QktzZNrRJmUKi38DAFcbFwgLaM\nG/iRIm4DDj2hmanKp+vUWjXfj13nasaswwa7bDtIlzW96y24jsu+naabg8MVShfGCStIv\nrX3T2JkkSjpTw7YzIpgI8/Zg9VR1l0udvfh9bn7sdakjsd92jkamjmOYc3EYwJKvuJDn1TzVuIIi\n9NmVasTjhZJ0PyWithWuZplo/LXUwSoid8HVyqe5ZVI=\n-----END CERTIFICATE REQUEST-----\n"
 r = provider_reg(email, '9845596200', name , org_id, bad_csr)
 assert r['success']     == False
-assert r['status_code'] == 403
+assert r['status_code'] == 400
 
 # large csr input
 bad_csr = "-----BEGIN CERTIFICATE REQUEST-----\n" + 'DEADCAFE' * 3000 + "\n-----END CERTIFICATE REQUEST-----\n"
 r = provider_reg(email, '9845596200', name , org_id, bad_csr)
 assert r['success']     == False
-assert r['status_code'] == 403
+assert r['status_code'] == 400
 
 # very large csr input, gets blocked by express itself?
 bad_csr = "-----BEGIN CERTIFICATE REQUEST-----\n" + 'DEADCAFE' * 30000 + "\n-----END CERTIFICATE REQUEST-----\n"
@@ -58,10 +58,10 @@ assert r['status_code'] == 403
 email = ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(6)) + '@gmail.com'
 r = provider_reg(email, '9845596200', name , '22329932', csr)
 assert r['success']     == False
-assert r['status_code'] == 404
+assert r['status_code'] == 403
 
 # invalid email
 email = "abcde1234--><><@x.y.z"
 r = provider_reg(email, '9845596200', name , org_id, csr)
 assert r['success']     == False
-assert r['status_code'] == 403
+assert r['status_code'] == 400

--- a/test/test-role-reg.py
+++ b/test/test-role-reg.py
@@ -21,9 +21,10 @@ email       = email_name + '@gmail.com'
 
 org_id = add_organization(website)
 
+# no role specified
 r = role_reg(email, '9454234223', name , [], None, csr)
 assert r['success']     == False
-assert r['status_code'] == 403
+assert r['status_code'] == 400
 
 r = role_reg(email, '9454234223', name , ["consumer"], None, csr)
 assert r['success']     == True
@@ -52,7 +53,7 @@ assert r['status_code'] == 200
 # invalid roles
 r = role_reg(email, '9454234223', name , ["onboarder", "provider"], org_id, csr)
 assert r['success']     == False
-assert r['status_code'] == 403
+assert r['status_code'] == 400
 
 # register as consumer with organisation mail
 r = role_reg(email, '9454234223', name , ["consumer"], None)
@@ -73,17 +74,17 @@ email = email_name + '@' + website
 # no csr
 r = role_reg(email, '9454234223', name , ["onboarder", "data ingester", "consumer"], org_id)
 assert r['success']     == False
-assert r['status_code'] == 403
+assert r['status_code'] == 400
 
 # bad csr
 r = role_reg(email, '9454234223', name , ["onboarder", "data ingester", "consumer"], org_id, bad_csr)
 assert r['success']     == False
-assert r['status_code'] == 403
+assert r['status_code'] == 400
 
 # invalid org ID
 r = role_reg(email, '9454234223', name , ["onboarder", "data ingester", "consumer"], 210781030, csr)
 assert r['success']     == False
-assert r['status_code'] == 404
+assert r['status_code'] == 403
 
 r = role_reg(email, '9454234223', name , ["onboarder", "data ingester", "consumer"], org_id, csr)
 assert r['success']     == True


### PR DESCRIPTION
* All emails received as external input made to lowercase after checking if empty/null
* Checks on organization ID (should be less than postgres int size)
* Updated error codes and messages for consent APIs to be more appropriate
* Added case during registration if unapproved provider tries to register for consumer/ingester/onboarder roles
    - The existing CSR will be used for certificate generation for them