### PR TITLE
Send JSON errors (400) if certificate error occurs at NGINX

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -43,6 +43,8 @@ server {
 	error_page 495 /client_ssl_error.json;
 	error_page 496 /ssl_error.json;
 	error_page 497 /https_error.json;
+	error_page 502 /bad_gateway.json;
+	error_page 503 /service_unavailable.json;
 
 	location /client_ssl_error.json {
 		return 400 '{"error":{"message":"Error occured during certificate verification. (Is your certificate expired?)"}}\n';
@@ -54,6 +56,14 @@ server {
 
 	location /https_error.json {
 		return 400 '{"error":{"message":"Invalid Request"}}\n';
+	}
+
+	location /bad_gateway.json {
+		return 502 '{"error":{"message":"Bad gateway"}}\n';
+	}
+
+	location /service_unavailable.json {
+		return 503 '{"error":{"message":"Service unavailable"}}\n';
 	}
 
 	# pass PHP scripts to FastCGI server

--- a/nginx.conf
+++ b/nginx.conf
@@ -40,6 +40,22 @@ server {
         # proxy_redirect      http://localhost:8080 https://jenkins.domain.com;
 	}
 
+	error_page 495 /client_ssl_error.json;
+	error_page 496 /ssl_error.json;
+	error_page 497 /https_error.json;
+
+	location /client_ssl_error.json {
+		return 400 '{"error":{"message":"Error occured during certificate verification. (Is your certificate expired?)"}}\n';
+	}
+
+	location /ssl_error.json {
+		return 400 '{"error":{"message":"No SSL certificate sent with request"}}\n';
+	}
+
+	location /https_error.json {
+		return 400 '{"error":{"message":"Invalid Request"}}\n';
+	}
+
 	# pass PHP scripts to FastCGI server
 	#
 	#location ~ \.php$ {


### PR DESCRIPTION
* NGINX sends a HTTP page when SSL/cert error occur
* Based on NGINX's error code (http://nginx.org/en/docs/http/ngx_http_ssl_module.html#errors)
  we respond with JSON errors, error code 400