### PR TITLE
Only apply rate limit on /token API, not on /token* APIs

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -69,7 +69,7 @@ server {
 		return 503 '{"error":{"message":"Service unavailable"}}\n';
 	}
 
-	location /auth/v1/token {
+	location = /auth/v1/token {
 
 	limit_conn addr 100;
 	limit_req zone=token burst=5 nodelay;


### PR DESCRIPTION
`location /auth/v1/token` will prefix match any API that begins with `/auth/v1/token`. Since introspect and revoke API have that prefix, we use an exact match with `=` to restrict rate-limiting to the token API