### PR TITLE
Registration updates, CORS updates

### DIFF
--- a/main.js
+++ b/main.js
@@ -223,7 +223,7 @@ app.use(timeout("5s"));
 app.use(
 	cors ({
 		credentials	:	true,
-		methods		:	["POST"],
+		methods		:	["POST", "GET", "PUT"],
 		origin		:	(origin, callback) =>
 					{
 						callback (
@@ -638,16 +638,15 @@ function is_secure (req, res, cert, validate_email = true)
 
 		if (
 			(! origin_domain.endsWith(".iudx.org.in"))	&&
-			(! origin_domain.endsWith(".datasetu.org"))	&&
-			(  origin_domain !== "datasetu.org"	)
+			(! origin_domain.endsWith(".iudx.io"))
 		)
 		{
 			return "Invalid 'origin' header; this website is not"	+
-				" whitelisted to call this API";
+				" permitted to call this API";
 		}
 
 		res.header("Access-Control-Allow-Origin", req.headers.origin);
-		res.header("Access-Control-Allow-Methods","POST");
+		res.header("Access-Control-Allow-Methods","POST, PUT, GET");
 	}
 
 	const error = is_certificate_ok (req,cert,validate_email);
@@ -4409,7 +4408,7 @@ app.all("/*", (req, res) => {
 	}
 	else
 	{
-		return END_ERROR (res, 405, "Method must be POST." + doc);
+		return END_ERROR (res, 405, "Method must be POST, PUT or GET" + doc);
 	}
 });
 

--- a/main.js
+++ b/main.js
@@ -4132,7 +4132,8 @@ app.post("/consent/v[1-2]/registration", async (req, res) => {
 
 	let user_id, signed_cert = null;
 	let check_orgid = false;
-	var existing_user = false;
+	let existing_user = false;
+	let message;
 
 	const phone_regex = new RegExp(/^[9876]\d{9}$/);
 
@@ -4235,6 +4236,9 @@ app.post("/consent/v[1-2]/registration", async (req, res) => {
 				if (uid !== null)
 					return END_ERROR (res, 403, "Already registered as " + val);
 			}
+
+			message = "Since you have registered before, please continue " +
+				  "to use the certificate that was sent before.";
 		}
 	}
 	catch(error)
@@ -4302,6 +4306,8 @@ app.post("/consent/v[1-2]/registration", async (req, res) => {
 		{
 			return END_ERROR (res, 500, "Internal error!", error);
 		}
+
+		message = "A certificate has been generated and sent to your email";
 	}
 
 	/* update org_id if the user was originally a consumer
@@ -4368,6 +4374,8 @@ app.post("/consent/v[1-2]/registration", async (req, res) => {
 		});
 	}
 
+	const response = {success : true, message : message};
+
 	const details	=
 		{
 			"id"  	: email,
@@ -4377,7 +4385,7 @@ app.post("/consent/v[1-2]/registration", async (req, res) => {
 
 	log("info", "USER_REGISTERED", false, details);
 
-	return END_SUCCESS (res);
+	return END_SUCCESS (res, response);
 });
 
 app.get("/consent/v[1-2]/organizations", async (req, res) => {

--- a/test/run
+++ b/test/run
@@ -6,7 +6,7 @@ error_code=0
 
 start_time=$(date +%s)
 
-for f in `ls test*.py`
+for f in `ls test-*.py`
 do
 	echo "-----> $f" | tee -a /tmp/report
 	output=`python3 $f`

--- a/test/test-role-reg.py
+++ b/test/test-role-reg.py
@@ -113,15 +113,15 @@ r = provider_reg(provider_email, '9454234223', name , org_id, csr)
 assert r['success']     == True
 assert r['status_code'] == 200
 
-# provider can get all other roles
+# provider cannot register other roles
 r = role_reg(provider_email, '9454234223', name , ["data ingester"], org_id, csr)
-assert r['success']     == True
-assert r['status_code'] == 200
+assert r['success']     == False
+assert r['status_code'] == 403
 
 r = role_reg(provider_email, '9454234223', name , ["onboarder"], org_id, csr)
-assert r['success']     == True
-assert r['status_code'] == 200
+assert r['success']     == False
+assert r['status_code'] == 403
 
 r = role_reg(provider_email, '9454234223', name , ["consumer"], org_id, csr)
-assert r['success']     == True
-assert r['status_code'] == 200
+assert r['success']     == False
+assert r['status_code'] == 403

--- a/test/test_role-reg.py
+++ b/test/test_role-reg.py
@@ -136,16 +136,16 @@ def test_provider_reg():
         assert r['success']     == True
         assert r['status_code'] == 200
 
-def test_provider_reg_other_roles():
+def test_provider_cannot_get_other_roles():
         # provider can get all other role
         r = role_reg(provider_email, '9454234223', name , ["data ingester"], org_id, csr)
-        assert r['success']     == True
-        assert r['status_code'] == 200
+        assert r['success']     == False
+        assert r['status_code'] == 403
 
         r = role_reg(provider_email, '9454234223', name , ["onboarder"], org_id, csr)
-        assert r['success']     == True
-        assert r['status_code'] == 200
+        assert r['success']     == False
+        assert r['status_code'] == 403
 
         r = role_reg(provider_email, '9454234223', name , ["consumer"], org_id, csr)
-        assert r['success']     == True
-        assert r['status_code'] == 200
+        assert r['success']     == False
+        assert r['status_code'] == 403


### PR DESCRIPTION
### Disable providers from registering as other roles
* If a user has registered as a provider before, they cannot
register as consumer/ingester/onboarder with the same email
whether they are approved/rejected/pending

### Send message indicating certificate status after registration
* If new user, say that cert has been created
* If existing user, say use cert that was sent before

### CORS changes
* Update methods in CORS middleware
* Add .iudx.io as permitted domain, remove datasetu
* Update methods in res.headers()

Small fix in tests