### PR TITLE
Delete rules

### DIFF
--- a/consent_schema.sql
+++ b/consent_schema.sql
@@ -97,8 +97,9 @@ CREATE TABLE consent.resourcegroup (
 CREATE TABLE consent.capability (
 
 	id			integer GENERATED ALWAYS AS IDENTITY	PRIMARY KEY,
-	access_id		integer REFERENCES consent.access(id)	NOT NULL,
-	capability		consent.capability_enum			NOT NULL
+	access_id		integer REFERENCES consent.access(id)	NOT NULL ON DELETE CASCADE,
+	capability		consent.capability_enum			NOT NULL,
+	UNIQUE (access_id, capability)
 );
 
 ALTER TABLE consent.organizations	OWNER TO postgres;

--- a/test/auth.py
+++ b/test/auth.py
@@ -171,6 +171,12 @@ class Auth():
                 return self.call("provider/access", body)
         #
 
+        def delete_rule(self, body):
+        #
+                body = body;
+                return self.call("provider/access", body, "DELETE")
+        #
+
         def get_provider_access(self):
         #
                 return self.call("provider/access", {}, "GET")

--- a/test/test-access.py
+++ b/test/test-access.py
@@ -114,8 +114,8 @@ r = untrusted.provider_access(email, 'consumer', resource_id, 'resourcegroup', c
 assert r['success']     == True
 assert r['status_code'] == 200
 
-apis = ["/ngsi-ld/v1/entityOperations/query", "/ngsi-ld/v1/entities", "/ngsi-ld/v1/temporal/entities","/ngsi-ld/v1/entities/" + resource_id, "/ngsi-ld/v1/subscription"]
-body = {"id" : resource_id + "/someitem", "apis" : apis }
+apis = ["/ngsi-ld/v1/entityOperations/query", "/ngsi-ld/v1/entities", "/ngsi-ld/v1/temporal/entities","/ngsi-ld/v1/entities/" + provider_id + '/rs.example.co.in/' + resource_group, "/ngsi-ld/v1/subscription"]
+body = {"id" : provider_id + '/rs.example.co.in/' + resource_group + "/someitem", "apis" : apis }
 r = consumer.get_token(body)
 
 assert r['success']     is True
@@ -156,10 +156,10 @@ assert r['status_code'] == 403
 
 ##### data ingester #####
 
-resource_group = ''.join(random.choice(string.ascii_lowercase) for _ in range(10))
-resource_id = provider_id + "/rs.example.com/" + resource_group
+diresource_group = ''.join(random.choice(string.ascii_lowercase) for _ in range(10))
+diresource_id = provider_id + "/rs.example.com/" + diresource_group
 
-body        = {"id" : resource_id + "/someitem", "api" : "/iudx/v1/adapter" }
+body        = {"id" : diresource_id + "/someitem", "api" : "/iudx/v1/adapter" }
 
 # data ingester token request should fail
 r = consumer.get_token(body)
@@ -170,17 +170,16 @@ assert r['success']     == True
 assert r['status_code'] == 200
 
 # invalid resource type
-r = untrusted.provider_access(email, 'data ingester', resource_id, 'catalogue')
+r = untrusted.provider_access(email, 'data ingester', diresource_id, 'catalogue')
 assert r['success']     == False
 assert r['status_code'] == 400
 
-r = untrusted.provider_access(email, 'data ingester', resource_id, 'resourcegroup')
+r = untrusted.provider_access(email, 'data ingester', diresource_id, 'resourcegroup')
 assert r['success']     == True
 assert r['status_code'] == 200
 
 # without adapter API
-body = {"id"    : resource_id + "/*" }
-
+body = {"id"    : diresource_id + "/*" }
 r = consumer.get_token(body)
 assert r['success']     is False
 
@@ -189,7 +188,7 @@ r = consumer.get_token(body)
 assert r['success']     is True
 
 # request for other items in resource group
-body = {"id" : resource_id + "/someitem/someotheritem", "api" : "/iudx/v1/adapter" }
+body = {"id" : diresource_id + "/someitem/someotheritem", "api" : "/iudx/v1/adapter" }
 r = consumer.get_token(body)
 assert r['success']     is True
 
@@ -208,11 +207,87 @@ assert r['success']     == True
 assert r['status_code'] == 200
 rules = r['response']
 for r in rules:
-        if r['email'] == email and r['role'] == 'consumer':
+        if r['email'] == email and r['role'] == 'consumer' and resource_id == r['item']['cat_id']:
+                consumer_id = r['id']
                 assert set(r['capabilities']).issubset(set(['temporal', 'subscription', 'complex']))
                 assert len(r['capabilities']) <= 3 and len(r['capabilities']) >= 1
         if r['email'] == email and r['role'] == 'onboarder':
+                onboarder_id = r['id']
                 assert r['item_type'] == 'catalogue'
-        if r['email'] == email and r['role'] == 'data ingester':
+        if r['email'] == email and r['role'] == 'data ingester' and diresource_id == r['item']['cat_id']:
+                ingester_id = r['id']
                 assert r['policy'].endswith('"/iudx/v1/adapter"')
 
+### deleting rules ###
+
+token_body = { "id"    : provider_id + "/catalogue.iudx.io/catalogue/crud" }
+
+r = consumer.get_token(token_body)
+assert r['success']     is True
+assert None != r['response']['token']
+
+body = {"id" : onboarder_id}
+r = untrusted.delete_rule([body])
+assert r['success']     == True
+assert r['status_code'] == 200
+
+# onboarder token request should fail
+r = consumer.get_token(token_body)
+assert r['success']     is False
+
+# 
+token_body = {"id" : diresource_id + "/someitem/someotheritem", "api" : "/iudx/v1/adapter" }
+r = consumer.get_token(token_body)
+assert r['success']     is True
+
+token_body = {"id" : resource_id + "/something", "apis" : ["/ngsi-ld/v1/temporal/entities"] }
+r = consumer.get_token(token_body)
+assert r['success']     is True
+
+body = [{"id": ingester_id}, {"id": consumer_id, "capability": ["temporal"]}]
+r = untrusted.delete_rule(body)
+assert r['success']     == True
+assert r['status_code'] == 200
+
+body = [{"id": ingester_id}, {"id": consumer_id, "capability": ["temporal"]}]
+r = untrusted.delete_rule(body)
+assert r['success']     == False
+assert r['status_code'] == 403
+
+token_body = {"id" : diresource_id + "/someitem/someotheritem", "api" : "/iudx/v1/adapter" }
+r = consumer.get_token(token_body)
+assert r['success']     is False
+
+token_body = {"id" : resource_id + "/something", "apis" : ["/ngsi-ld/v1/temporal/entities"] }
+r = consumer.get_token(token_body)
+assert r['success']     is False
+
+# get token for subscription, complex
+apis = ["/ngsi-ld/v1/entityOperations/query", "/ngsi-ld/v1/entities","/ngsi-ld/v1/entities/" +  resource_id, "/ngsi-ld/v1/subscription"]
+token_body = {"id" : resource_id + "/someitem", "apis" : apis }
+r = consumer.get_token(token_body)
+assert r['success']     is True
+
+# temporal not there
+body = [{"id": consumer_id, "capability": ["temporal", "subscription", "complex"]}]
+r = untrusted.delete_rule(body)
+assert r['success']     == False
+assert r['status_code'] == 403
+
+token_body = {"id" : resource_id + "/someitem", "apis" : apis }
+r = consumer.get_token(token_body)
+assert r['success']     is True
+
+# delete full rule
+body = [{"id": consumer_id}]
+r = untrusted.delete_rule(body)
+assert r['success']     == True
+assert r['status_code'] == 200
+
+token_body = {"id" : resource_id + "/someitem", "apis" : apis }
+r = consumer.get_token(token_body)
+assert r['success']     is False
+
+token_body = {"id" : resource_id + "/someitem", "apis" : ["/ngsi-ld/v1/subscription"] }
+r = consumer.get_token(token_body)
+assert r['success']     is False


### PR DESCRIPTION
* request is array of objects, each containing access ID
* if need to delete individual capability, add array of caps to
  be deleted to the object
* Added policy text generation function (TODO, refactor POST API to use this)
* Updated tests

* Added cascade delete on capability if access rule deleted
* Added unique constraint on access id + capability