### PR TITLE
Add provider delegate feature

### DIFF
--- a/consent_schema.sql
+++ b/consent_schema.sql
@@ -19,7 +19,7 @@ GRANT USAGE ON SCHEMA consent TO auth;
 
 CREATE TYPE consent.status_enum AS ENUM ('rejected', 'pending', 'approved');
 CREATE TYPE consent.role_enum 	AS ENUM ('consumer', 'data ingester', 'onboarder', 'delegate', 'provider', 'admin');
-CREATE TYPE consent.access_item AS ENUM ('resourcegroup', 'catalogue');
+CREATE TYPE consent.access_item AS ENUM ('resourcegroup', 'catalogue', 'delegate');
 CREATE TYPE consent.capability_enum AS ENUM ('temporal', 'complex', 'subscription');
 
 CREATE TABLE consent.organizations (

--- a/consent_schema.sql
+++ b/consent_schema.sql
@@ -83,6 +83,7 @@ CREATE TABLE consent.access (
 	policy_text		character varying				NOT NULL,
 	access_item_id		integer 						,
 	access_item_type	consent.access_item					,
+	owner_id		integer REFERENCES consent.role(id)		ON DELETE SET NULL,
 	created_at		timestamp without time zone			NOT NULL,
 	updated_at		timestamp without time zone			NOT NULL
 );

--- a/consent_schema.sql
+++ b/consent_schema.sql
@@ -18,7 +18,7 @@ GRANT ALL ON SCHEMA consent to postgres;
 GRANT USAGE ON SCHEMA consent TO auth;
 
 CREATE TYPE consent.status_enum AS ENUM ('rejected', 'pending', 'approved');
-CREATE TYPE consent.role_enum 	AS ENUM ('consumer', 'data ingester', 'onboarder', 'provider', 'admin');
+CREATE TYPE consent.role_enum 	AS ENUM ('consumer', 'data ingester', 'onboarder', 'delegate', 'provider', 'admin');
 CREATE TYPE consent.access_item AS ENUM ('resourcegroup', 'catalogue');
 CREATE TYPE consent.capability_enum AS ENUM ('temporal', 'complex', 'subscription');
 

--- a/main.js
+++ b/main.js
@@ -895,6 +895,9 @@ async function set_acl(provider_id, uid, rules, callback)
 
 			rules = result.rows.map(
 				(row) => { return row.policy_text; });
+
+			/* remove empty strings (delegate rules) */
+			rules = rules.filter((val) => val !== "");
 		}
 		catch(error)
 		{
@@ -3558,11 +3561,16 @@ app.post("/auth/v[1-2]/provider/access", async (req, res) => {
 			}
 		}
 
-		/* access_item_id for catalogue is -1 by default */
+		/* access_item_id for catalogue/delegate is -1 by default */
 		if (accesser_role === "onboarder")
 		{
 			access_item_id 	= -1;
 			res_type 	= "catalogue";
+		}
+		else if (accesser_role === "delegate")
+		{
+			access_item_id 	= -1;
+			res_type 	= "delegate";
 		}
 
 		/* if rule exists for particular provider+accesser+role+
@@ -3701,6 +3709,10 @@ app.post("/auth/v[1-2]/provider/access", async (req, res) => {
 
 			case "consumer":
 				rule = ``; /* use create_consumer_policy_text function */
+				break;
+
+			case "delegate":
+				rule = ``; /* empty policy for delegate access */
 				break;
 
 			default:
@@ -3853,7 +3865,8 @@ app.get("/auth/v[1-2]/provider/access",  async (req, res) => {
 
 	for (const item of access_items)
 	{
-		if (item === "catalogue") continue;
+		if (item === "catalogue" || item === "delegate")
+			continue;
 
 		try {
 			const result = await pool.query (

--- a/main.js
+++ b/main.js
@@ -3699,7 +3699,7 @@ app.post("/auth/v[1-2]/provider/access", async (req, res) => {
 				break;
 
 			case "consumer":
-				rule = `${accesser_email} can access ${resource_name}/* for 1 week`;
+				rule = ``; /* use create_consumer_policy_text function */
 				break;
 
 			default:
@@ -3710,7 +3710,6 @@ app.post("/auth/v[1-2]/provider/access", async (req, res) => {
 		if (accesser_role === "consumer")
 		{
 			let caps, existing_caps = [];
-			let join = "if", index;
 
 			if (consumer_acc_id !== null)
 			{/* get existing capabilities if existing rule */
@@ -3731,19 +3730,7 @@ app.post("/auth/v[1-2]/provider/access", async (req, res) => {
 
 			let capability = existing_caps.concat(req_capability);
 
-			let apis = capability.reduce((acc, val) => acc.concat(CAPABILITIES[val]), []);
-			apis = [...new Set(apis)];
-
-			/* if latest API is there, then add resource group
-			 * to the template */
-			if ((index = apis.indexOf(LATEST)) !== -1)
-				apis[index] = apis[index](resource);
-
-			for (const i of apis)
-			{
-				rule = rule + ` ${join} api = "${i}"`;
-				join = "or";
-			}
+			rule = create_consumer_policy_text(accesser_email, resource, resource_name, capability);
 		}
 
 		try {

--- a/test/access.py
+++ b/test/access.py
@@ -25,7 +25,6 @@ cursor = conn.cursor()
 
 def init_provider():
 
-
         org_id = add_organization("rbccps.org")
 
         # use abc.xyz@rbccps.org certificate as provider
@@ -35,6 +34,7 @@ def init_provider():
         try:
                 cursor.execute("update consent.role as rr set status = 'approved' from consent.users where " + " users.id = rr.user_id and users.email = 'abc.xyz@rbccps.org'")
                 cursor.execute("delete from consent.access using consent.users where access.provider_id = users.id and email = 'abc.xyz@rbccps.org' and access_item_type = 'catalogue'")
+                cursor.execute("delete from consent.access using consent.users where access.provider_id = users.id and email = 'abc.xyz@rbccps.org' and access_item_type = 'delegate'")
                 conn.commit()
 
         except psycopg2.DatabaseError as error:

--- a/test/auth.py
+++ b/test/auth.py
@@ -16,7 +16,7 @@ class Auth():
                 self.credentials        = (certificate, key)
         #
 
-        def call(self, api, body=None, method = "POST", params=None):
+        def call(self, api, body=None, method = "POST", params=None, header={}):
         #
                 ret = True # success
 
@@ -31,7 +31,7 @@ class Auth():
                         cert        = self.credentials,
                         data        = body,
                         params      = params,
-                        headers     = {"content-type":"application/json"}
+                        headers     = {"content-type":"application/json", **header}
                 )
 
                 if response.status_code != 200:
@@ -159,21 +159,34 @@ class Auth():
                 return self.call("group/list", body)
         #
 
-        def provider_access(self, body):
+        def provider_access(self, request, provider_email=None):
         #
-                body = body;
-                return self.call("provider/access", body)
+                header = {}
+
+                if provider_email:
+                        header['provider-email'] = provider_email
+
+                return self.call("provider/access", request, "POST", {}, header)
         #
 
-        def delete_rule(self, body):
+        def delete_rule(self, request, provider_email=None):
         #
-                body = body;
-                return self.call("provider/access", body, "DELETE")
+                header = {}
+
+                if provider_email:
+                        header['provider-email'] = provider_email
+
+                return self.call("provider/access", request, "DELETE", {}, header)
         #
 
-        def get_provider_access(self):
+        def get_provider_access(self, provider_email=None):
         #
-                return self.call("provider/access", {}, "GET")
+                header = {}
+
+                if provider_email:
+                        header['provider-email'] = provider_email
+
+                return self.call("provider/access", {}, "GET", {}, header)
         #
 
         def organization_reg(self, org):

--- a/test/test-access-delegate.py
+++ b/test/test-access-delegate.py
@@ -1,0 +1,307 @@
+from init import untrusted
+from init import alt_provider
+from init import consumer
+from access import *
+from consent import role_reg
+import random
+import string
+
+init_provider()
+
+# use consumer certificate to register
+email   = "barun@iisc.ac.in"
+assert reset_role(email) == True
+org_id = add_organization("iisc.ac.in")
+r = role_reg(email, '9454234223', name , ["consumer","onboarder","data ingester", "delegate"], org_id, csr)
+assert r['success']     == True
+assert r['status_code'] == 200
+
+# delete all old policies using acl/set API
+policy = "x can access x"
+r = untrusted.set_policy(policy)
+assert r['success'] is True
+
+# use alt_provider certificate as delegate
+delegate_email = "abc.123@iisc.ac.in"
+assert reset_role(delegate_email) == True
+
+# provider ID of abc.xyz@rbccps.org
+provider_id = 'rbccps.org/f3dad987e514af08a4ac46cf4a41bd1df645c8cc'
+
+# register abc.123 as delegate and set delegate rule
+
+r = role_reg(delegate_email, '9454234223', name , ["delegate"], org_id, csr)
+assert r['success']     == True
+assert r['status_code'] == 200
+
+resource_group = ''.join(random.choice(string.ascii_lowercase) for _ in range(10))
+resource_id = provider_id + '/rs.example.com/' + resource_group
+
+# token request should fail
+body = {"id" : resource_id + "/someitem", "apis" : ["/ngsi-ld/v1/entities"] }
+r = consumer.get_token(body)
+assert r['success']     is False
+
+# set temporal consumer rule as delegate
+req = {"user_email": email, "user_role":'consumer', "item_id":resource_id, "item_type":"resourcegroup"}
+req["capabilities"] = ['temporal']
+
+# should fail because unapproved delegate
+r = alt_provider.provider_access([req], 'abc.xyz@rbccps.org')
+assert r['success']     == False
+assert r['status_code'] == 401
+
+req = {"user_email": delegate_email, "user_role":'delegate'}
+r = untrusted.provider_access([req])
+assert r['success']     == True
+assert r['status_code'] == 200
+
+req = {"user_email": email, "user_role":'consumer', "item_id":resource_id, "item_type":"resourcegroup"}
+req["capabilities"] = ['temporal']
+
+# fail because provider_email missing
+r = alt_provider.provider_access([req])
+assert r['success']     == False
+assert r['status_code'] == 400
+
+# invalid provider_email
+r = alt_provider.provider_access([req], 'abc.xyz$$@$$rbccps.org')
+assert r['success']     == False
+assert r['status_code'] == 400
+
+# non-existent provider
+r = alt_provider.provider_access([req], 'provider@rbccps.org')
+assert r['success']     == False
+assert r['status_code'] == 401
+
+# valid
+r = alt_provider.provider_access([req], 'abc.xyz@rbccps.org')
+assert r['success']     == True
+assert r['status_code'] == 200
+
+body = {"id" : resource_id + "/someitem", "apis" : ["/ngsi-ld/v1/entities/" + resource_id] }
+r = consumer.get_token(body)
+assert r['success']     is True
+
+# provider can update consumer rule set by delegate
+
+req = {"user_email": email, "user_role":'consumer', "item_id":resource_id, "item_type":"resourcegroup"}
+req["capabilities"] = ['complex'];
+r = untrusted.provider_access([req])
+assert r['success']     == True
+assert r['status_code'] == 200
+
+body = {"id" : resource_id + "/someitem", "apis" : ["/ngsi-ld/v1/entities"] }
+r = consumer.get_token(body)
+assert r['success']     is True
+
+# delegate cannot update rule set by provider
+
+pr_resource_group = ''.join(random.choice(string.ascii_lowercase) for _ in range(10))
+pr_resource_id = provider_id + '/rs.example.in/' + resource_group
+
+req = {"user_email": email, "user_role":'consumer', "item_id":pr_resource_id, "item_type":"resourcegroup"}
+req["capabilities"] = ['complex'];
+r = untrusted.provider_access([req])
+assert r['success']     == True
+assert r['status_code'] == 200
+
+req = {"user_email": email, "user_role":'consumer', "item_id":pr_resource_id, "item_type":"resourcegroup"}
+req["capabilities"] = ['temporal'];
+r = alt_provider.provider_access([req], 'abc.xyz@rbccps.org')
+assert r['success']     == False
+assert r['status_code'] == 403
+
+body = {"id" : resource_id + "/someitem", "apis" : ["/ngsi-ld/v1/entities"] }
+r = consumer.get_token(body)
+assert r['success']     is True
+
+body = {"id" : resource_id + "/someitem", "apis" : ["/ngsi-ld/v1/temporal/entities/"] }
+r = consumer.get_token(body)
+assert r['success']     is False
+
+# delegate can set onboarder rule
+
+body = { "id"    : provider_id + "/catalogue.iudx.io/catalogue/crud" }
+
+# onboarder token request should fail
+r = consumer.get_token(body)
+assert r['success']     is False
+
+req = {"user_email": email, "user_role":'onboarder'}
+r = alt_provider.provider_access([req], 'abc.xyz@rbccps.org')
+assert r['success']     == True
+assert r['status_code'] == 200
+
+r = consumer.get_token(body)
+assert r['success']     is True
+assert None != r['response']['token']
+
+# delegate can set ingester rule
+
+diresource_group = ''.join(random.choice(string.ascii_lowercase) for _ in range(10))
+diresource_id = provider_id + "/rs.example.com/" + diresource_group
+
+body        = {"id" : diresource_id + "/someitem", "api" : "/iudx/v1/adapter" }
+
+# data ingester token request should fail
+r = consumer.get_token(body)
+assert r['success']     is False
+
+req = {"user_email": email, "user_role":'data ingester', "item_id":diresource_id, "item_type":"resourcegroup"}
+r = alt_provider.provider_access([req], 'abc.xyz@rbccps.org')
+assert r['success']     == True
+assert r['status_code'] == 200
+
+# without adapter API
+body        = {"id" : diresource_id + "/someitem", "api" : "/iudx/v1/adapter" }
+r = consumer.get_token(body)
+assert r['success']     is True
+
+# delegate cannot set delegate rule
+
+req = {"user_email": email, "user_role":'delegate'}
+r = alt_provider.provider_access([req], 'abc.xyz@rbccps.org')
+assert r['success']     == False
+assert r['status_code'] == 403
+
+# test getting all access rules
+
+r = alt_provider.get_provider_access('abc.xyz@rbccps.org')
+assert r['success']     == True
+assert r['status_code'] == 200
+rules = r['response']
+
+check_con = False
+check_onb = False
+check_dti = False
+check_del = False
+
+for r in rules:
+        if r['email'] == email and r['role'] == 'consumer' and resource_id == r['item']['cat_id']:
+                consumer_id = r['id']
+                assert set(r['capabilities']).issubset(set(['temporal', 'subscription', 'complex']))
+                assert len(r['capabilities']) <= 3 and len(r['capabilities']) >= 1
+                assert r['owner']['email'] == delegate_email
+                check_con = True
+        if r['email'] == email and r['role'] == 'consumer' and pr_resource_id == r['item']['cat_id']:
+                provider_set_consumer_id = r['id']
+        if r['email'] == email and r['role'] == 'onboarder':
+                onboarder_id = r['id']
+                assert r['item_type'] == 'catalogue'
+                assert r['owner']['email'] == delegate_email
+                check_onb = True
+        if r['email'] == email and r['role'] == 'data ingester' and diresource_id == r['item']['cat_id']:
+                ingester_id = r['id']
+                assert r['policy'].endswith('"/iudx/v1/adapter"')
+                assert r['owner']['email'] == delegate_email
+                check_dti = True
+        if r['email'] == delegate_email and r['role'] == 'delegate':
+                delegate_id = r['id']
+                assert r['item_type'] == 'delegate'
+                assert r['owner']['email'] == 'abc.xyz@rbccps.org'
+                check_del = True
+
+assert check_con == True
+assert check_onb == True
+assert check_dti == True
+assert check_del == True
+
+# deleting rules
+
+# delete rules set by delegate
+r = alt_provider.delete_rule([{"id" : onboarder_id}, {"id": consumer_id}], 'abc.xyz@rbccps.org')
+assert r['success']     == True
+assert r['status_code'] == 200
+
+# provider can delete rules set by delegate
+r = untrusted.delete_rule([{"id": ingester_id}])
+assert r['success']     == True
+assert r['status_code'] == 200
+
+r = alt_provider.delete_rule([{"id": ingester_id}], 'abc.xyz@rbccps.org')
+assert r['success']     == False
+assert r['status_code'] == 403
+
+# cannot delete rule set by provider
+
+body = {"id" : provider_set_consumer_id}
+r = alt_provider.delete_rule([body], 'abc.xyz@rbccps.org')
+assert r['success']     == False
+assert r['status_code'] == 403
+
+# cannot delete delegate rule
+body = {"id" : delegate_id}
+r = alt_provider.delete_rule([body], 'abc.xyz@rbccps.org')
+assert r['success']     == False
+assert r['status_code'] == 403
+
+# tests with 2 delegates
+
+# make consumer a delegate
+req = {"user_email": email, "user_role":'delegate'}
+r = untrusted.provider_access([req])
+assert r['success']     == True
+assert r['status_code'] == 200
+
+resource_group = ''.join(random.choice(string.ascii_lowercase) for _ in range(10))
+resource_id = provider_id + '/rs.example.com/' + resource_group
+
+req = {"user_email": email, "user_role":'consumer', "item_id":resource_id, "item_type":"resourcegroup"}
+req["capabilities"] = ['complex'];
+r = consumer.provider_access([req], 'abc.xyz@rbccps.org')
+assert r['success']     == True
+assert r['status_code'] == 200
+
+# cannot update rule set by other provider
+req["capabilities"] = ['subscription'];
+r = alt_provider.provider_access([req], 'abc.xyz@rbccps.org')
+assert r['success']     == False
+assert r['status_code'] == 403
+
+r = consumer.get_provider_access('abc.xyz@rbccps.org')
+assert r['success']     == True
+assert r['status_code'] == 200
+rules = r['response']
+
+for r in rules:
+        if r['email'] == email and r['role'] == 'consumer' and resource_id == r['item']['cat_id']:
+                consumer_id = r['id']
+                assert r['owner']['email'] == email
+
+# one delegate cannot delete other delegate's rule
+body = {"id" : consumer_id}
+r = alt_provider.delete_rule([body], 'abc.xyz@rbccps.org')
+assert r['success']     == False
+assert r['status_code'] == 403
+
+body = {"id" : consumer_id}
+r = consumer.delete_rule([body], 'abc.xyz@rbccps.org')
+assert r['success']     == True
+assert r['status_code'] == 200
+
+# delegate cannot delete delegate rule
+r = consumer.delete_rule([{"id": delegate_id}], 'abc.xyz@rbccps.org')
+assert r['success']     == False
+assert r['status_code'] == 403
+
+# provider deletes delegate
+r = untrusted.delete_rule([{"id": delegate_id}])
+assert r['success']     == True
+assert r['status_code'] == 200
+
+# deleted delegate cannot do anything
+req = {"user_email": email, "user_role":'consumer', "item_id":resource_id, "item_type":"resourcegroup"}
+req["capabilities"] = ['complex'];
+r = alt_provider.provider_access([req], 'abc.xyz@rbccps.org')
+assert r['success']     == False
+assert r['status_code'] == 401
+
+r = alt_provider.get_provider_access('abc.xyz@rbccps.org')
+assert r['success']     == False
+assert r['status_code'] == 401
+
+body = {"id" : consumer_id}
+r = alt_provider.delete_rule([body], 'abc.xyz@rbccps.org')
+assert r['success']     == False
+assert r['status_code'] == 401

--- a/test/test-access.py
+++ b/test/test-access.py
@@ -157,6 +157,22 @@ r = untrusted.provider_access([req])
 assert r['success']     == False
 assert r['status_code'] == 403
 
+##### delegate #####
+
+r = role_reg(email, '9454234223', name , ["delegate"], org_id)
+assert r['success']     == True
+assert r['status_code'] == 200
+
+req["user_role"] = "delegate"
+r = untrusted.provider_access([req])
+assert r['success']     == True
+assert r['status_code'] == 200
+
+req["user_role"] = "delegate"
+r = untrusted.provider_access([req])
+assert r['success']     == False
+assert r['status_code'] == 403
+
 ##### data ingester #####
 
 diresource_group = ''.join(random.choice(string.ascii_lowercase) for _ in range(10))
@@ -309,7 +325,7 @@ email = email_name + '@iisc.ac.in'
 req = {"user_email": email, "user_role":'consumer', "item_id":resource_id, "item_type":"resourcegroup", "capabilities":["temporal"]}
 req1 = {"user_email": email, "user_role":'onboarder'}
 
-r = role_reg(email, '9454234223', name , ["onboarder", "consumer", "data ingester"], org_id, csr)
+r = role_reg(email, '9454234223', name , ["onboarder", "consumer", "data ingester", "delegate"], org_id, csr)
 assert r['success']     == True
 assert r['status_code'] == 200
 
@@ -319,7 +335,7 @@ assert r['success']     == False
 assert r['status_code'] == 400
 
 # valid
-r = untrusted.provider_access([req1, req])
+r = untrusted.provider_access([req1, req, {"user_email": email, "user_role":'delegate'}])
 assert r['success']     == True
 assert r['status_code'] == 200
 
@@ -387,6 +403,8 @@ assert r['status_code'] == 200
 check_con = False
 check_onb = False
 check_dti = False
+check_del = False
+
 r = untrusted.get_provider_access()
 assert r['success']     == True
 assert r['status_code'] == 200
@@ -399,6 +417,9 @@ for r in rules:
         if r['email'] == email and r['role'] == 'onboarder':
                 assert r['item_type'] == 'catalogue'
                 check_onb = True
+        if r['email'] == email and r['role'] == 'delegate':
+                assert r['item_type'] == 'delegate'
+                check_del = True
         if r['email'] == email and r['role'] == 'data ingester':
                 assert r['policy'].endswith('"/iudx/v1/adapter"')
                 check_dti = True
@@ -406,3 +427,4 @@ for r in rules:
 assert check_con == True
 assert check_onb == True
 assert check_dti == True
+assert check_del == True

--- a/test/test-role-reg.py
+++ b/test/test-role-reg.py
@@ -55,8 +55,22 @@ r = role_reg(email, '9454234223', name , ["onboarder", "provider"], org_id, csr)
 assert r['success']     == False
 assert r['status_code'] == 400
 
-# register as consumer with organisation mail
-r = role_reg(email, '9454234223', name , ["consumer"], None)
+# register as consumer with organisation mail, no phone
+r = role_reg(email, '', name , ["consumer"], None)
+assert r['success']     == True
+assert r['status_code'] == 200
+
+# register as delegate without org ID
+r = role_reg(email, '9454234223', name , ["delegate"], None)
+assert r['success']     == False
+assert r['status_code'] == 400
+
+# need phone number when registering as delegate
+r = role_reg(email, '', name , ["delegate"], org_id, csr)
+assert r['success']     == False
+assert r['status_code'] == 400
+
+r = role_reg(email, '9454234223', name , ["delegate"], org_id)
 assert r['success']     == True
 assert r['status_code'] == 200
 
@@ -65,28 +79,33 @@ email_name  = ''.join(random.choice(string.ascii_lowercase + string.digits) for 
 email       = email_name + '@gmail.com' 
 
 # all roles - non-org email
-r = role_reg(email, '9454234223', name , ["onboarder", "data ingester", "consumer"], org_id, csr)
+r = role_reg(email, '9454234223', name , ["onboarder", "data ingester", "consumer", "delegate"], org_id, csr)
 assert r['success']     == False
 assert r['status_code'] == 403
 
 email = email_name + '@' + website
 
 # no csr
-r = role_reg(email, '9454234223', name , ["onboarder", "data ingester", "consumer"], org_id)
+r = role_reg(email, '9454234223', name , ["onboarder", "data ingester", "consumer", "delegate"], org_id)
 assert r['success']     == False
 assert r['status_code'] == 400
 
 # bad csr
-r = role_reg(email, '9454234223', name , ["onboarder", "data ingester", "consumer"], org_id, bad_csr)
+r = role_reg(email, '9454234223', name , ["onboarder", "data ingester", "consumer", "delegate"], org_id, bad_csr)
 assert r['success']     == False
 assert r['status_code'] == 400
 
 # invalid org ID
-r = role_reg(email, '9454234223', name , ["onboarder", "data ingester", "consumer"], 210781030, csr)
+r = role_reg(email, '9454234223', name , ["onboarder", "data ingester", "consumer", "delegate"], 210781030, csr)
 assert r['success']     == False
 assert r['status_code'] == 403
 
-r = role_reg(email, '9454234223', name , ["onboarder", "data ingester", "consumer"], org_id, csr)
+# no phone number for delegate
+r = role_reg(email, '', name , ["onboarder", "data ingester", "consumer", "delegate"], org_id, csr)
+assert r['success']     == False
+assert r['status_code'] == 400
+
+r = role_reg(email, '9454234223', name , ["onboarder", "data ingester", "consumer", "delegate"], org_id, csr)
 assert r['success']     == True
 assert r['status_code'] == 200
 

--- a/test/test_access-delegate.py
+++ b/test/test_access-delegate.py
@@ -1,0 +1,338 @@
+from init import untrusted
+from init import alt_provider
+from init import consumer
+from access import *
+from consent import role_reg
+import random
+import string
+import pytest
+
+# use consumer certificate to register
+email   = "barun@iisc.ac.in"
+org_id = add_organization("iisc.ac.in")
+
+# use alt_provider certificate as delegate
+delegate_email = "abc.123@iisc.ac.in"
+
+# provider ID of abc.xyz@rbccps.org
+provider_id = 'rbccps.org/f3dad987e514af08a4ac46cf4a41bd1df645c8cc'
+
+resource_group = ''.join(random.choice(string.ascii_lowercase) for _ in range(10))
+resource_id = provider_id + '/rs.example.com/' + resource_group
+
+pr_resource_group = ''.join(random.choice(string.ascii_lowercase) for _ in range(10))
+pr_resource_id = provider_id + '/rs.example.in/' + resource_group
+
+diresource_group = ''.join(random.choice(string.ascii_lowercase) for _ in range(10))
+diresource_id = provider_id + "/rs.example.com/" + diresource_group
+
+consumer_id = -1
+onboarder_id = -1
+ingester_id = -1
+delegate_id = -1
+provider_set_consumer_id = -1
+
+@pytest.fixture(scope="session", autouse=True)
+def init():
+        init_provider()
+        assert reset_role(email) == True
+        assert reset_role(delegate_email) == True
+
+        # delete all old policies using acl/set API
+        policy = "x can access x"
+        r = untrusted.set_policy(policy)
+        assert r['success'] is True
+
+        # register abc.123 as delegate and set delegate rule
+        r = role_reg(delegate_email, '9454234223', name , ["delegate"], org_id, csr)
+        assert r['success']     == True
+        assert r['status_code'] == 200
+
+        # register barun user as all roles
+        r = role_reg(email, '9454234223', name , ["consumer","onboarder","data ingester", "delegate"], org_id, csr)
+        assert r['success']     == True
+        assert r['status_code'] == 200
+
+def test_set_rule_unassigned_delegate():
+
+        # token request should fail
+        body = {"id" : resource_id + "/someitem", "apis" : ["/ngsi-ld/v1/entities"] }
+        r = consumer.get_token(body)
+        assert r['success']     is False
+
+        # set temporal consumer rule as delegate
+        req = {"user_email": email, "user_role":'consumer', "item_id":resource_id, "item_type":"resourcegroup"}
+        req["capabilities"] = ['temporal']
+
+        # should fail because unapproved delegate
+        r = alt_provider.provider_access([req], 'abc.xyz@rbccps.org')
+        assert r['success']     == False
+        assert r['status_code'] == 401
+
+def test_assign_delegate_register_consumer():
+
+        req = {"user_email": delegate_email, "user_role":'delegate'}
+        r = untrusted.provider_access([req])
+        assert r['success']     == True
+        assert r['status_code'] == 200
+
+def test_delegate_invalid_provider_email():
+        req = {"user_email": email, "user_role":'consumer', "item_id":resource_id, "item_type":"resourcegroup"}
+        req["capabilities"] = ['temporal']
+
+        # fail because provider_email missing
+        r = alt_provider.provider_access([req])
+        assert r['success']     == False
+        assert r['status_code'] == 400
+
+        # invalid provider_email
+        r = alt_provider.provider_access([req], 'abc.xyz@rbccps$$.')
+        assert r['success']     == False
+        assert r['status_code'] == 400
+
+        # non-existent provider
+        r = alt_provider.provider_access([req], 'provider@rbccps.org')
+        assert r['success']     == False
+        assert r['status_code'] == 401
+
+def test_delegate_set_consumer_rule():
+        req = {"user_email": email, "user_role":'consumer', "item_id":resource_id, "item_type":"resourcegroup"}
+        req["capabilities"] = ['temporal']
+        r = alt_provider.provider_access([req], 'abc.xyz@rbccps.org')
+        assert r['success']     == True
+        assert r['status_code'] == 200
+
+        body = {"id" : resource_id + "/someitem", "apis" : ["/ngsi-ld/v1/entities/" + resource_id] }
+        r = consumer.get_token(body)
+        assert r['success']     is True
+
+def test_provider_update_rule_set_by_delegate():
+        # provider can update consumer rule set by delegate
+
+        req = {"user_email": email, "user_role":'consumer', "item_id":resource_id, "item_type":"resourcegroup"}
+        req["capabilities"] = ['complex'];
+        r = untrusted.provider_access([req], 'abc.xyz@rbccps.org')
+        assert r['success']     == True
+        assert r['status_code'] == 200
+
+        body = {"id" : resource_id + "/someitem", "apis" : ["/ngsi-ld/v1/entities"] }
+        r = consumer.get_token(body)
+        assert r['success']     is True
+
+def test_delegate_update_provider_rule():
+        # delegate cannot update rule set by provider
+
+        req = {"user_email": email, "user_role":'consumer', "item_id":pr_resource_id, "item_type":"resourcegroup"}
+        req["capabilities"] = ['complex'];
+        r = untrusted.provider_access([req])
+        assert r['success']     == True
+        assert r['status_code'] == 200
+
+        req = {"user_email": email, "user_role":'consumer', "item_id":pr_resource_id, "item_type":"resourcegroup"}
+        req["capabilities"] = ['temporal'];
+        r = alt_provider.provider_access([req], 'abc.xyz@rbccps.org')
+        assert r['success']     == False
+        assert r['status_code'] == 403
+
+        body = {"id" : resource_id + "/someitem", "apis" : ["/ngsi-ld/v1/entities"] }
+        r = consumer.get_token(body)
+        assert r['success']     is True
+
+        body = {"id" : resource_id + "/someitem", "apis" : ["/ngsi-ld/v1/temporal/entities/"] }
+        r = consumer.get_token(body)
+        assert r['success']     is False
+
+def test_delegate_set_onboarder_rule():
+        # delegate can set onboarder rule
+
+        body = { "id"    : provider_id + "/catalogue.iudx.io/catalogue/crud" }
+
+        # onboarder token request should fail
+        r = consumer.get_token(body)
+        assert r['success']     is False
+
+        req = {"user_email": email, "user_role":'onboarder'}
+        r = alt_provider.provider_access([req], 'abc.xyz@rbccps.org')
+        assert r['success']     == True
+        assert r['status_code'] == 200
+
+        r = consumer.get_token(body)
+        assert r['success']     is True
+        assert None != r['response']['token']
+
+def test_delegate_set_ingester_rule():
+        # delegate can set ingester rule
+        body        = {"id" : diresource_id + "/someitem", "api" : "/iudx/v1/adapter" }
+
+        # data ingester token request should fail
+        r = consumer.get_token(body)
+        assert r['success']     is False
+
+        req = {"user_email": email, "user_role":'data ingester', "item_id":diresource_id, "item_type":"resourcegroup"}
+        r = alt_provider.provider_access([req], 'abc.xyz@rbccps.org')
+        assert r['success']     == True
+        assert r['status_code'] == 200
+
+        # without adapter API
+        body        = {"id" : diresource_id + "/someitem", "api" : "/iudx/v1/adapter" }
+        r = consumer.get_token(body)
+        assert r['success']     is True
+
+def test_delegate_set_delegate_rule():
+        # delegate cannot set delegate rule
+
+        req = {"user_email": email, "user_role":'delegate'}
+        r = alt_provider.provider_access([req], 'abc.xyz@rbccps.org')
+        assert r['success']     == False
+        assert r['status_code'] == 403
+
+def test_delegate_get_all_rules():
+        # test getting all access rules
+        global consumer_id, onboarder_id, ingester_id, delegate_id, provider_set_consumer_id
+
+        r = alt_provider.get_provider_access('abc.xyz@rbccps.org')
+        assert r['success']     == True
+        assert r['status_code'] == 200
+        rules = r['response']
+
+        check_con = False
+        check_onb = False
+        check_dti = False
+        check_del = False
+
+        for r in rules:
+                if r['email'] == email and r['role'] == 'consumer' and resource_id == r['item']['cat_id']:
+                        consumer_id = r['id']
+                        assert set(r['capabilities']).issubset(set(['temporal', 'subscription', 'complex']))
+                        assert len(r['capabilities']) <= 3 and len(r['capabilities']) >= 1
+                        assert r['owner']['email'] == delegate_email
+                        check_con = True
+                if r['email'] == email and r['role'] == 'consumer' and pr_resource_id == r['item']['cat_id']:
+                        provider_set_consumer_id = r['id']
+                if r['email'] == email and r['role'] == 'onboarder':
+                        onboarder_id = r['id']
+                        assert r['item_type'] == 'catalogue'
+                        assert r['owner']['email'] == delegate_email
+                        check_onb = True
+                if r['email'] == email and r['role'] == 'data ingester' and diresource_id == r['item']['cat_id']:
+                        ingester_id = r['id']
+                        assert r['policy'].endswith('"/iudx/v1/adapter"')
+                        assert r['owner']['email'] == delegate_email
+                        check_dti = True
+                if r['email'] == delegate_email and r['role'] == 'delegate':
+                        delegate_id = r['id']
+                        assert r['item_type'] == 'delegate'
+                        assert r['owner']['email'] == 'abc.xyz@rbccps.org'
+                        check_del = True
+
+        assert check_con == True
+        assert check_onb == True
+        assert check_dti == True
+        assert check_del == True
+
+# deleting rules
+
+def test_delegate_delete_rules_set_by_self():
+        # delete rules set by delegate
+        r = alt_provider.delete_rule([{"id" : onboarder_id}, {"id": consumer_id}], 'abc.xyz@rbccps.org')
+        assert r['success']     == True
+        assert r['status_code'] == 200
+
+def test_provider_delete_rule_set_by_delegate():
+        # provider can delete rules set by delegate
+        r = untrusted.delete_rule([{"id": ingester_id}])
+        assert r['success']     == True
+        assert r['status_code'] == 200
+
+        r = alt_provider.delete_rule([{"id": ingester_id}], 'abc.xyz@rbccps.org')
+        assert r['success']     == False
+        assert r['status_code'] == 403
+
+def test_delegate_delete_provider_rule():
+        # cannot delete rule set by provider
+        body = {"id" : provider_set_consumer_id}
+        r = alt_provider.delete_rule([body], 'abc.xyz@rbccps.org')
+        assert r['success']     == False
+        assert r['status_code'] == 403
+
+def test_delegate_delete_delegate_rule():
+        # cannot delete delegate rule
+        body = {"id" : delegate_id}
+        r = alt_provider.delete_rule([body], 'abc.xyz@rbccps.org')
+        assert r['success']     == False
+        assert r['status_code'] == 403
+
+def test_multiple_delegates():
+        # tests with 2 delegates
+
+        # make consumer a delegate
+        req = {"user_email": email, "user_role":'delegate'}
+        r = untrusted.provider_access([req])
+        assert r['success']     == True
+        assert r['status_code'] == 200
+
+        resource_group = ''.join(random.choice(string.ascii_lowercase) for _ in range(10))
+        resource_id = provider_id + '/rs.example.com/' + resource_group
+
+        req = {"user_email": email, "user_role":'consumer', "item_id":resource_id, "item_type":"resourcegroup"}
+        req["capabilities"] = ['complex'];
+        r = consumer.provider_access([req], 'abc.xyz@rbccps.org')
+        assert r['success']     == True
+        assert r['status_code'] == 200
+
+        # cannot update rule set by other provider
+        req["capabilities"] = ['subscription'];
+        r = alt_provider.provider_access([req], 'abc.xyz@rbccps.org')
+        assert r['success']     == False
+        assert r['status_code'] == 403
+
+        r = consumer.get_provider_access('abc.xyz@rbccps.org')
+        assert r['success']     == True
+        assert r['status_code'] == 200
+        rules = r['response']
+
+        for r in rules:
+                if r['email'] == email and r['role'] == 'consumer' and resource_id == r['item']['cat_id']:
+                        consumer_id = r['id']
+                        assert r['owner']['email'] == email
+
+        # one delegate cannot delete other delegate's rule
+        body = {"id" : consumer_id}
+        r = alt_provider.delete_rule([body], 'abc.xyz@rbccps.org')
+        assert r['success']     == False
+        assert r['status_code'] == 403
+
+        body = {"id" : consumer_id}
+        r = consumer.delete_rule([body], 'abc.xyz@rbccps.org')
+        assert r['success']     == True
+        assert r['status_code'] == 200
+
+        # delegate cannot delete delegate rule
+        r = consumer.delete_rule([{"id": delegate_id}], 'abc.xyz@rbccps.org')
+        assert r['success']     == False
+        assert r['status_code'] == 403
+
+def test_deleted_delegate():
+        # provider deletes delegate
+
+        global consumer_id
+
+        r = untrusted.delete_rule([{"id": delegate_id}])
+        assert r['success']     == True
+        assert r['status_code'] == 200
+
+        # deleted delegate cannot do anything
+        req = {"user_email": email, "user_role":'consumer', "item_id":resource_id, "item_type":"resourcegroup"}
+        req["capabilities"] = ['complex'];
+        r = alt_provider.provider_access([req], 'abc.xyz@rbccps.org')
+        assert r['success']     == False
+        assert r['status_code'] == 401
+
+        r = alt_provider.get_provider_access('abc.xyz@rbccps.org')
+        assert r['success']     == False
+        assert r['status_code'] == 401
+
+        body = {"id" : consumer_id}
+        r = alt_provider.delete_rule([body], 'abc.xyz@rbccps.org')
+        assert r['success']     == False
+        assert r['status_code'] == 401

--- a/test/test_access.py
+++ b/test/test_access.py
@@ -202,6 +202,27 @@ def test_set_onboarder_rule_again():
         assert r['success']     == False
         assert r['status_code'] == 403
 
+##### delegate #####
+
+def test_reg_delegate():
+        r = role_reg(email, '9454234223', name , ["delegate"], org_id)
+        assert r['success']     == True
+        assert r['status_code'] == 200
+
+def test_set_delegate_rule():
+        global req
+        req["user_role"] = "delegate"
+        r = untrusted.provider_access([req])
+        assert r['success']     == True
+        assert r['status_code'] == 200
+
+def test_set_delegate_rule_again():
+        global req
+        req["user_role"] = "delegate"
+        r = untrusted.provider_access([req])
+        assert r['success']     == False
+        assert r['status_code'] == 403
+
 ##### data ingester #####
 
 diresource_group = ''.join(random.choice(string.ascii_lowercase) for _ in range(10))
@@ -371,7 +392,7 @@ def test_delete_consumer_rule():
 remail_name  = ''.join(random.choice(string.ascii_lowercase + string.digits) for _ in range(6)) 
 remail = remail_name + '@iisc.ac.in'
 
-r = role_reg(remail, '9454234223', name , ["onboarder", "consumer", "data ingester"], org_id, csr)
+r = role_reg(remail, '9454234223', name , ["onboarder", "consumer", "data ingester", "delegate"], org_id, csr)
 assert r['success']     == True
 assert r['status_code'] == 200
 
@@ -387,7 +408,7 @@ def test_multiple_duplicate():
         assert r['status_code'] == 400
 
 def test_multiple_onb_temporal():
-        r = untrusted.provider_access([_req1, _req])
+        r = untrusted.provider_access([_req1, _req, {"user_email": remail, "user_role":'delegate'}])
         assert r['success']     == True
         assert r['status_code'] == 200
 
@@ -458,6 +479,8 @@ def test_multiple_get_all_rules():
         check_con = False
         check_onb = False
         check_dti = False
+        check_del = False
+
         r = untrusted.get_provider_access()
         assert r['success']     == True
         assert r['status_code'] == 200
@@ -470,6 +493,9 @@ def test_multiple_get_all_rules():
                 if r['email'] == remail and r['role'] == 'onboarder':
                         assert r['item_type'] == 'catalogue'
                         check_onb = True
+                if r['email'] == remail and r['role'] == 'delegate':
+                        assert r['item_type'] == 'delegate'
+                        check_del = True
                 if r['email'] == remail and r['role'] == 'data ingester':
                         assert r['policy'].endswith('"/iudx/v1/adapter"')
                         check_dti = True
@@ -477,3 +503,4 @@ def test_multiple_get_all_rules():
         assert check_con == True
         assert check_onb == True
         assert check_dti == True
+        assert check_del == True

--- a/test/test_access.py
+++ b/test/test_access.py
@@ -4,12 +4,10 @@ from access import *
 from consent import role_reg
 import random
 import string
-
-init_provider()
+import pytest
 
 # use consumer certificate to register
 email   = "barun@iisc.ac.in"
-assert reset_role(email) == True
 org_id = add_organization("iisc.ac.in")
 
 ingester_id = 0 
@@ -17,14 +15,18 @@ consumer_id = 0
 onboarder_id = 0
 cat_id = ''
 
-# delete all old policies using acl/set API
-policy = "x can access x"
-r = untrusted.set_policy(policy)
-assert r['success'] is True
-
 # provider ID of abc.xyz@rbccps.org
 provider_id = 'rbccps.org/f3dad987e514af08a4ac46cf4a41bd1df645c8cc'
 
+@pytest.fixture(scope="session", autouse=True)
+def init():
+        init_provider()
+        assert reset_role(email) == True
+
+        # delete all old policies using acl/set API
+        policy = "x can access x"
+        r = untrusted.set_policy(policy)
+        assert r['success'] is True
 
 ##### consumer #####
 
@@ -40,6 +42,7 @@ def test_consumer_no_rule_set():
         assert r['success']     is False
 
 def test_consumer_reg():
+        assert reset_role(email) == True
         r = role_reg(email, '9454234223', name , ["consumer"], None, csr)
         assert r['success']     == True
         assert r['status_code'] == 200
@@ -213,6 +216,7 @@ def test_set_delegate_rule():
         global req
         req["user_role"] = "delegate"
         r = untrusted.provider_access([req])
+        print(r)
         assert r['success']     == True
         assert r['status_code'] == 200
 

--- a/test/test_role-reg.py
+++ b/test/test_role-reg.py
@@ -66,9 +66,29 @@ def test_invalid_role():
         assert r['status_code'] == 400
 
 def test_org_email_consumer():
-        # register as consumer with organisation mail
+        # register as consumer with organisation mail w/o phone
         email = email_name + '@' + website
-        r = role_reg(email, '9454234223', name , ["consumer"], None)
+        r = role_reg(email, '', name , ["consumer"], None)
+        assert r['success']     == True
+        assert r['status_code'] == 200
+
+def test_delegate_without_org_id():
+        # register as delegate without org ID
+        email = email_name + '@' + website
+        r = role_reg(email, '9454234223', name , ["delegate"], None)
+        assert r['success']     == False
+        assert r['status_code'] == 400
+
+def test_delegate_without_phone():
+        # need phone number when registering as delegate
+        email = email_name + '@' + website
+        r = role_reg(email, '', name , ["delegate"], org_id, csr)
+        assert r['success']     == False
+        assert r['status_code'] == 400
+
+def test_delegate_reg():
+        email = email_name + '@' + website
+        r = role_reg(email, '9454234223', name , ["delegate"], org_id)
         assert r['success']     == True
         assert r['status_code'] == 200
 
@@ -78,34 +98,40 @@ new_email_name  = ''.join(random.choice(string.ascii_lowercase + string.digits) 
 def test_non_org_email():
         # all roles - non-org email
         email       = new_email_name + '@gmail.com' 
-        r = role_reg(email, '9454234223', name , ["onboarder", "data ingester", "consumer"], org_id, csr)
+        r = role_reg(email, '9454234223', name , ["onboarder", "data ingester", "consumer", "delegate"], org_id, csr)
         assert r['success']     == False
         assert r['status_code'] == 403
 
 def test_no_csr():
         # no csr
         email       = new_email_name + '@' + website 
-        r = role_reg(email, '9454234223', name , ["onboarder", "data ingester", "consumer"], org_id)
+        r = role_reg(email, '9454234223', name , ["onboarder", "data ingester", "consumer", "delegate"], org_id)
         assert r['success']     == False
         assert r['status_code'] == 400
 
 def test_bad_csr():
         # bad csr
         email       = new_email_name + '@' + website 
-        r = role_reg(email, '9454234223', name , ["onboarder", "data ingester", "consumer"], org_id, bad_csr)
+        r = role_reg(email, '9454234223', name , ["onboarder", "data ingester", "consumer", "delegate"], org_id, bad_csr)
         assert r['success']     == False
         assert r['status_code'] == 400
 
 def test_invalid_org_id():
         # invalid org ID
         email       = new_email_name + '@' + website 
-        r = role_reg(email, '9454234223', name , ["onboarder", "data ingester", "consumer"], 210781030, csr)
+        r = role_reg(email, '9454234223', name , ["onboarder", "data ingester", "consumer", "delegate"], 210781030, csr)
         assert r['success']     == False
         assert r['status_code'] == 403
 
+def test_missing_phone():
+        email       = new_email_name + '@' + website 
+        r = role_reg(email, '', name , ["onboarder", "data ingester", "consumer", "delegate"], org_id, csr)
+        assert r['success']     == False
+        assert r['status_code'] == 400
+
 def test_all_role_reg():
         email       = new_email_name + '@' + website 
-        r = role_reg(email, '9454234223', name , ["onboarder", "data ingester", "consumer"], org_id, csr)
+        r = role_reg(email, '9454234223', name , ["onboarder", "data ingester", "consumer", "delegate"], org_id, csr)
         assert r['success']     == True
         assert r['status_code'] == 200
 


### PR DESCRIPTION
* Update `consent_schema.sql`
    - Added 'delegate' to access_item enum and role_enum
    - Added owner_id` col to access table - role ID of user who created the rule
* Added delegate registration
    - needs phone number, org ID. Same flow as onboarder/ingester
* Added delegate rule creation
    - Only provider can create delegate rule
* Added ability for delegate to create,read,update rules
    - Delegate can create new rules
    - Delegate can only modify, delete rules set by them
* Added tests for all new features
