### PR TITLE
Stqc fixes

### DIFF
--- a/main.js
+++ b/main.js
@@ -3856,6 +3856,9 @@ app.delete("/auth/v[1-2]/provider/access", async (req, res) => {
 
 	for (const obj of res.locals.body)
 	{
+		if (typeof obj !== "object" || obj === null)  
+			return END_ERROR (res, 400, "Invalid data (body)");
+
 		let id = obj.id;
 		let capability = obj.capabilities || null;
 		let delete_rule = false;

--- a/test/test-access.py
+++ b/test/test-access.py
@@ -244,6 +244,12 @@ token_body = {"id" : resource_id + "/something", "apis" : ["/ngsi-ld/v1/temporal
 r = consumer.get_token(token_body)
 assert r['success']     is True
 
+# invalid body, some items not objects
+body = [ingester_id, ["complex"], {"id": consumer_id, "capabilities": ["temporal"]}]
+r = untrusted.delete_rule(body)
+assert r['success']     == False
+assert r['status_code'] == 400
+
 body = [{"id": ingester_id}, {"id": consumer_id, "capabilities": ["temporal"]}]
 r = untrusted.delete_rule(body)
 assert r['success']     == True

--- a/test/test-groups.py
+++ b/test/test-groups.py
@@ -53,6 +53,7 @@ provider.set_policy('all can access iisc.iudx.org.in/resource-xyz* if consumer-i
 
 body = {
 	"id"	: "rbccps.org/9cf2c2382cf661fc20a4776345a3be7a143a109c/iisc.iudx.org.in/resource-xyz-yzz",
+        "apis"  : ["/ngsi-ld/v1/temporal/entities"]
 }
 
 provider.add_consumer_to_group("barun@iisc.ac.in","confidential",100)

--- a/test/test_access.py
+++ b/test/test_access.py
@@ -292,6 +292,12 @@ def test_delete_ingester_temporal():
         r = consumer.get_token(token_body)
         assert r['success']     is True
 
+        # invalid body, some items not objects
+        body = [ingester_id, ["complex"], {"id": consumer_id, "capabilities": ["temporal"]}]
+        r = untrusted.delete_rule(body)
+        assert r['success']     == False
+        assert r['status_code'] == 400
+
         body = [{"id": ingester_id}, {"id": consumer_id, "capabilities": ["temporal"]}]
         r = untrusted.delete_rule(body)
         assert r['success']     == True


### PR DESCRIPTION
- Removed token_hash from logging
- Added validation for name and titles for registration APIs
- Added hex validation for token hashes, serial and fingerprint for revoke and revoke all APIs
- Check if all items sent in DELETE access array are objects
- Token API requires apis to be from among consumer/data ingester APIs
    - If catalogue/onboader token request, then 'apis' array is changed to '[/*]'
    - If other resource server, then
	- APIs must be among consumer/ingester APIs
	- 'apis' array must not be empty
     - Updated old tests to have 'apis' field in token request
