### PR TITLE
Stqc/bug fix

### DIFF
--- a/consent_schema.sql
+++ b/consent_schema.sql
@@ -79,6 +79,7 @@ CREATE TABLE consent.access (
 	provider_id		integer NOT NULL REFERENCES consent.users(id) 	ON DELETE CASCADE,
 	role_id			integer REFERENCES consent.role(id)		ON DELETE CASCADE,
 	policy_text		character varying				NOT NULL,
+	policy_json		jsonb						NOT NULL,
 	access_item_id		integer 						,
 	access_item_type	consent.access_item					,
 	created_at		timestamp without time zone			NOT NULL,

--- a/consent_schema.sql
+++ b/consent_schema.sql
@@ -34,7 +34,6 @@ CREATE TABLE consent.organizations (
 	updated_at	timestamp without time zone		NOT NULL
 );
 
-CREATE UNIQUE INDEX idx_organizations_id ON consent.organizations(id);
 CREATE UNIQUE INDEX idx_organizations_website ON consent.organizations(website);
 
 CREATE TABLE consent.users (
@@ -50,7 +49,6 @@ CREATE TABLE consent.users (
 	updated_at	timestamp without time zone			NOT NULL
 );
 
-CREATE UNIQUE INDEX idx_users_id ON consent.users(id);
 CREATE UNIQUE INDEX idx_users_email ON consent.users(email);
 
 CREATE TABLE consent.role (
@@ -63,7 +61,7 @@ CREATE TABLE consent.role (
 	updated_at	timestamp without time zone			NOT NULL
 );
 
-CREATE UNIQUE INDEX idx_role_id ON consent.role(id);
+CREATE INDEX idx_role_user_id ON consent.role(user_id);
 
 CREATE TABLE consent.certificates (
 
@@ -87,7 +85,8 @@ CREATE TABLE consent.access (
 	updated_at		timestamp without time zone			NOT NULL
 );
 
-CREATE UNIQUE INDEX idx_access_id ON consent.access(id);
+CREATE INDEX idx_access_provider_id ON consent.access(provider_id);
+CREATE INDEX idx_access_role_id ON consent.access(role_id);
 
 CREATE TABLE consent.resourcegroup (
 
@@ -105,6 +104,8 @@ CREATE TABLE consent.capability (
 	capability		consent.capability_enum				NOT NULL,
 	UNIQUE (access_id, capability)
 );
+
+CREATE INDEX idx_capability_access_id ON consent.capability(access_id);
 
 ALTER TABLE consent.organizations	OWNER TO postgres;
 ALTER TABLE consent.users		OWNER TO postgres;

--- a/consent_schema.sql
+++ b/consent_schema.sql
@@ -98,6 +98,9 @@ CREATE TABLE consent.resourcegroup (
 	updated_at		timestamp without time zone				NOT NULL
 );
 
+CREATE INDEX idx_resourcegroup_provider_id ON consent.resourcegroup(provider_id);
+CREATE UNIQUE INDEX idx_resourcegroup_cat_id ON consent.resourcegroup(cat_id);
+
 CREATE TABLE consent.capability (
 
 	id			integer GENERATED ALWAYS AS IDENTITY		PRIMARY KEY,

--- a/main.js
+++ b/main.js
@@ -24,7 +24,6 @@ const safe_regex		= require("safe-regex");
 const nodemailer		= require("nodemailer");
 const geoip_lite		= require("geoip-lite");
 const bodyParser		= require("body-parser");
-const compression		= require("compression");
 const http_request		= require("request");
 const pgNativeClient		= require("pg-native");
 
@@ -193,14 +192,6 @@ pg.connectSync (
 		}
 );
 
-/* --- preload negotiator's encoding module for gzip compression --- */
-
-const Negotiator = require("negotiator");
-const negotiator = new Negotiator();
-
-try		{ negotiator.encodings(); }
-catch(x)	{ /* ignore */ }
-
 /* --- express --- */
 
 const app = express();
@@ -223,7 +214,6 @@ app.use(
 	})
 );
 
-app.use(compression());
 app.use(bodyParser.raw({type:"*/*"}));
 
 app.use(parse_cert_header);

--- a/scripts/add_json_policy_to_db.js
+++ b/scripts/add_json_policy_to_db.js
@@ -1,0 +1,104 @@
+/* This script converts the policy_text column in the access table
+ * to json and inserts into the policy_json column. 
+ * In /home/iudx-auth-server, run `node add_json_policy_to_db.js`
+ */
+
+"use strict";
+
+const fs			= require("fs");
+const aperture			= require("./node-aperture");
+const Pool			= require("pg").Pool;
+
+/* --- postgres --- */
+
+const DB_SERVER	= "127.0.0.1";
+
+const password	= {
+	"DB"	: fs.readFileSync("passwords/auth.db.password","ascii").trim(),
+};
+
+const pool = new Pool ({
+	host		: DB_SERVER,
+	port		: 5432,
+	user		: "auth",
+	database	: "postgres",
+	password	: password.DB,
+});
+
+pool.connect();
+
+/* --- aperture --- */
+
+const apertureOpts = {
+
+	types		: aperture.types,
+	typeTable	: {
+
+		ip			: "ip",
+		time			: "time",
+
+		tokens_per_day		: "number",	// tokens issued today
+
+		api			: "string",	// the API to be called
+		method			: "string",	// the method for API
+
+		"cert.class"		: "number",	// the certificate class
+		"cert.cn"		: "string",
+		"cert.o"		: "string",
+		"cert.ou"		: "string",
+		"cert.c"		: "string",
+		"cert.st"		: "string",
+		"cert.gn"		: "string",
+		"cert.sn"		: "string",
+		"cert.title"		: "string",
+
+		"cert.issuer.cn"	: "string",
+		"cert.issuer.email"	: "string",
+		"cert.issuer.o"		: "string",
+		"cert.issuer.ou"	: "string",
+		"cert.issuer.c"		: "string",
+		"cert.issuer.st"	: "string",
+
+		groups			: "string",	// CSV actually
+
+		country			: "string",
+		region			: "string",
+		timezone		: "string",
+		city			: "string",
+		latitude		: "number",
+		longitude		: "number",
+	}
+};
+const parser	= aperture.createParser(apertureOpts);
+
+async function main()
+{
+	let rules;
+	try {
+		const result = await pool.query ("SELECT id, policy_text FROM consent.access",[]);
+		rules = result.rows;
+	}
+	catch(error)
+	{
+		console.log("Error in query");
+	}
+	for (let rule of rules)
+	{
+		let json = parser.parse(rule.policy_text);
+		try {
+			const result = await pool.query (
+				"UPDATE consent.access SET policy_json = $1::jsonb WHERE id = $2::integer",
+				[json, rule.id]);
+		}
+		catch(error)
+		{
+			console.log("Error in query");
+		}
+	}
+
+	return;
+}
+
+main()
+console.log("Done");
+process.exit();

--- a/test/access.py
+++ b/test/access.py
@@ -23,18 +23,24 @@ except psycopg2.DatabaseError as error:
 
 cursor = conn.cursor()
 
-def init_provider():
+# create a provider role for the email address
+def init_provider(email):
+        
+        org_domain = email.split('@')[1]
 
-
-        org_id = add_organization("rbccps.org")
-
-        # use abc.xyz@rbccps.org certificate as provider
-        # do not assert, can already be approved
-        r = provider_reg("abc.xyz@rbccps.org", '7529547992', name , org_id, csr)
+        org_id = add_organization(org_domain)
 
         try:
-                cursor.execute("update consent.role as rr set status = 'approved' from consent.users where " + " users.id = rr.user_id and users.email = 'abc.xyz@rbccps.org'")
-                cursor.execute("delete from consent.access using consent.users where access.provider_id = users.id and email = 'abc.xyz@rbccps.org' and access_item_type = 'catalogue'")
+                cursor.execute("delete from consent.users where users.email = '" + email + "'")
+                conn.commit()
+
+        except psycopg2.DatabaseError as error:
+                return {}
+
+        r = provider_reg(email, '7529547992', name , org_id, csr)
+
+        try:
+                cursor.execute("update consent.role as rr set status = 'approved' from consent.users where " + " users.id = rr.user_id and users.email = '" + email + "'")
                 conn.commit()
 
         except psycopg2.DatabaseError as error:
@@ -44,7 +50,7 @@ def reset_role(email):
 # set all roles with this email as rejected
         
         try:
-                cursor.execute("update consent.role as rr set status = 'rejected' from consent.users where users.id = rr.user_id and users.email = '" + email + "'")
+                cursor.execute("delete from  consent.users where  users.email = '" + email + "'")
                 conn.commit()
 
         except psycopg2.DatabaseError as error:

--- a/test/test-access.py
+++ b/test/test-access.py
@@ -20,10 +20,11 @@ provider_id = 'rbccps.org/f3dad987e514af08a4ac46cf4a41bd1df645c8cc'
 resource_group = ''.join(random.choice(string.ascii_lowercase) for _ in range(10))
 resource_id = provider_id + '/rs.example.com/' + resource_group
 
-# token request should fail
+# token request should fail - not registered
 body = {"id" : resource_id + "/someitem", "apis" : ["/ngsi-ld/v1/entities"] }
 r = consumer.get_token(body)
 assert r['success']     is False
+assert r['status_code'] == 401
 
 r = role_reg(email, '9454234223', name , ["consumer"], None, csr)
 assert r['success']     == True
@@ -54,6 +55,7 @@ assert r['status_code'] == 403
 body    = { "id"    : resource_id + "/someitem"}
 r       = consumer.get_token(body)
 assert r['success']     is False
+assert r['status_code'] == 400
 
 body = {"id" : resource_id + "/someitem", "apis" : ["/ngsi-ld/v1/entities/" + resource_id] }
 r = consumer.get_token(body)
@@ -63,6 +65,7 @@ assert r['success']     is True
 body = {"id" : resource_id + "/someitem", "apis" : ["/ngsi-ld/v1/entities", "/ngsi-ld/v1/temporal/entities"] }
 r = consumer.get_token(body)
 assert r['success']     is False
+assert r['status_code'] == 403
 
 body = {"id" : resource_id + "/someitem", "apis" : ["/ngsi-ld/v1/temporal/entities"] }
 r = consumer.get_token(body)
@@ -72,6 +75,7 @@ assert r['success']     is True
 body = {"id" : resource_id + "/someitem", "apis" : ["/ngsi-ld/v1/entityOperations/query"] }
 r = consumer.get_token(body)
 assert r['success']     is False
+assert r['status_code'] == 403
 
 # temporal rule already exists
 caps = ['subscription', 'temporal'];
@@ -132,6 +136,7 @@ body = { "id"    : provider_id + "/catalogue.iudx.io/catalogue/crud" }
 # onboarder token request should fail
 r = consumer.get_token(body)
 assert r['success']     is False
+assert r['status_code'] == 403
 
 r = role_reg(email, '9454234223', name , ["onboarder"], org_id)
 assert r['success']     == True
@@ -159,6 +164,7 @@ body        = {"id" : diresource_id + "/someitem", "api" : "/iudx/v1/adapter" }
 # data ingester token request should fail
 r = consumer.get_token(body)
 assert r['success']     is False
+assert r['status_code'] == 403
 
 r = role_reg(email, '9454234223', name , ["data ingester"], org_id)
 assert r['success']     == True
@@ -177,6 +183,7 @@ assert r['status_code'] == 200
 body = {"id"    : diresource_id + "/*" }
 r = consumer.get_token(body)
 assert r['success']     is False
+assert r['status_code'] == 400
 
 body["api"] = "/iudx/v1/adapter"
 r = consumer.get_token(body)
@@ -229,8 +236,8 @@ assert r['status_code'] == 200
 # onboarder token request should fail
 r = consumer.get_token(token_body)
 assert r['success']     is False
+assert r['status_code'] == 403
 
-# 
 token_body = {"id" : diresource_id + "/someitem/someotheritem", "api" : "/iudx/v1/adapter" }
 r = consumer.get_token(token_body)
 assert r['success']     is True
@@ -258,10 +265,12 @@ assert r['status_code'] == 403
 token_body = {"id" : diresource_id + "/someitem/someotheritem", "api" : "/iudx/v1/adapter" }
 r = consumer.get_token(token_body)
 assert r['success']     is False
+assert r['status_code'] == 403
 
 token_body = {"id" : resource_id + "/something", "apis" : ["/ngsi-ld/v1/temporal/entities"] }
 r = consumer.get_token(token_body)
 assert r['success']     is False
+assert r['status_code'] == 403
 
 # get token for subscription, complex
 apis = ["/ngsi-ld/v1/entityOperations/query", "/ngsi-ld/v1/entities","/ngsi-ld/v1/entities/" +  resource_id, "/ngsi-ld/v1/subscription"]
@@ -288,7 +297,9 @@ assert r['status_code'] == 200
 token_body = {"id" : resource_id + "/someitem", "apis" : apis }
 r = consumer.get_token(token_body)
 assert r['success']     is False
+assert r['status_code'] == 403
 
 token_body = {"id" : resource_id + "/someitem", "apis" : ["/ngsi-ld/v1/subscription"] }
 r = consumer.get_token(token_body)
 assert r['success']     is False
+assert r['status_code'] == 403

--- a/test/test-access.py
+++ b/test/test-access.py
@@ -5,17 +5,12 @@ from consent import role_reg
 import random
 import string
 
-init_provider()
+init_provider("xyz.abc@rbccps.org")
 
 # use consumer certificate to register
 email   = "barun@iisc.ac.in"
 assert reset_role(email) == True
 org_id = add_organization("iisc.ac.in")
-
-# delete all old policies using acl/set API
-policy = "x can access x"
-r = untrusted.set_policy(policy)
-assert r['success'] is True
 
 # provider ID of abc.xyz@rbccps.org
 provider_id = 'rbccps.org/f3dad987e514af08a4ac46cf4a41bd1df645c8cc'

--- a/test/test-tokens.py
+++ b/test/test-tokens.py
@@ -12,43 +12,55 @@ from init import expect_failure
 
 from init import restricted_consumer
 
+# for registration and resetting roles
+from access import *
+from consent import role_reg
+
 import hashlib
 
 RS = "iisc.iudx.org.in"
 
 TUPLE = type(("x",))
 
-policy = "x can access *" # dummy policy
-provider.set_policy(policy)
+# register the providers
+init_provider("arun.babu@rbccps.org") # provider
+init_provider("abc.123@iisc.ac.in") # alt_provider
 
-policy = 'all can access * for 2 hours if tokens_per_day < 100'
-provider.set_policy(policy)
+# register the consumer
+email   = "barun@iisc.ac.in"
+assert reset_role(email) == True
+org_id = add_organization("iisc.ac.in")
 
-assert policy in provider.get_policy()['response']['policy']
+r = role_reg(email, '9454234223', name , ["consumer"], None, csr)
+assert r['success']     == True
+assert r['status_code'] == 200
 
-new_policy  = "*@rbccps.org can access resource-yyz-abc for 1 hour"
-assert provider.append_policy(new_policy)['success'] is True
+# set policies using access API
+caps = ["complex"]
+r = provider.provider_access(email, 'consumer', "rbccps.org/9cf2c2382cf661fc20a4776345a3be7a143a109c/" + RS + "/resource-xyz-yzz", 'resourcegroup', caps)
+assert r['success']     == True
+assert r['status_code'] == 200
 
-x = provider.get_policy()['response']['policy']
-assert new_policy in x
-assert policy in x
+caps = ["temporal"]
+r = provider.provider_access(email, 'consumer', "rbccps.org/9cf2c2382cf661fc20a4776345a3be7a143a109c/abc.com/abc-xyz", 'resourcegroup', caps)
+assert r['success']     == True
+assert r['status_code'] == 200
 
 r = provider.audit_tokens(5)
 assert r['success'] is True
 audit_report        = r['response']
 as_provider         = audit_report["as-provider"]
 
-
 num_tokens_before = len(as_provider)
 body = [
         {
-                "id"    : "rbccps.org/9cf2c2382cf661fc20a4776345a3be7a143a109c/" + RS + "/resource-xyz-yzz",
+                "id"    : "rbccps.org/9cf2c2382cf661fc20a4776345a3be7a143a109c/" + RS + "/resource-xyz-yzz/*",
                 "apis"          : ["/ngsi-ld/v1/entities"],
-                "methods"       : ["GET"],
+                "method"        : "GET",
                 "body"          : {"key":"some-key"}
         },
         {
-                "id"    : "rbccps.org/9cf2c2382cf661fc20a4776345a3be7a143a109c/abc.com/abc-xyz",
+                "id"    : "rbccps.org/9cf2c2382cf661fc20a4776345a3be7a143a109c/abc.com/abc-xyz/item",
                 "apis"  : ["/ngsi-ld/v1/entities/rbccps.org/9cf2c2382cf661fc20a4776345a3be7a143a109c/abc.com/abc-xyz"],
         }
 ]
@@ -58,7 +70,7 @@ access_token = r['response']
 
 assert r['success']     is True
 assert None             != access_token
-assert 60*60*2          == access_token['expires-in']
+assert 60*60*24*7       == access_token['expires-in']
 
 token = access_token['token'],
 
@@ -78,10 +90,11 @@ assert resource_server.introspect_token (token,server_token)['success'] is True
 # introspect once more
 assert resource_server.introspect_token (token,server_token)['success'] is True
 
+
 # introspect with request
 request = [
             {
-                "id"    : "rbccps.org/9cf2c2382cf661fc20a4776345a3be7a143a109c/" + RS + "/resource-xyz-yzz",
+                "id"    : "rbccps.org/9cf2c2382cf661fc20a4776345a3be7a143a109c/" + RS + "/resource-xyz-yzz/*",
                 "apis"          : ["/ngsi-ld/v1/entities"],
                 "methods"       : ["GET"],
                 "body"          : {"key":"some-key"}
@@ -146,17 +159,16 @@ for a in as_provider:
                 found = a
                 break
 
-
 assert token_hash_found is True
 assert found['revoked'] is True
 
 # test revoke-all (as provider)
-r = provider.get_token(body)
+r = consumer.get_token(body)
 access_token = r['response']
 
 assert r['success']     is True
 assert None             != access_token
-assert 60*60*2          == access_token['expires-in']
+assert 60*60*24*7       == access_token['expires-in']
 
 token = access_token['token']
 
@@ -195,60 +207,18 @@ for a in as_provider:
                 if a['expired'] is False:
                         assert a['revoked'] is True
 
-# test revoke API
-r = provider.get_token(body)
-access_token = r['response']
-
-assert r['success']     is True
-assert None             != access_token
-assert 60*60*2          == access_token['expires-in']
-
-token = access_token['token']
-
-if type(token) == TUPLE:
-        token = token[0]
-
-s = token.split("/")
-
-assert len(s)   == 3
-assert s[0]     == 'auth.iudx.org.in'
-
-r = provider.audit_tokens(5)
-assert r["success"] is True
-audit_report        = r['response']
-as_consumer         = audit_report["as-consumer"]
-num_revoked_before  = 0
-
-for a in as_consumer:
-        if a['revoked'] is True:
-                num_revoked_before = num_revoked_before + 1
-
-r = provider.revoke_tokens(token)
-assert r["success"] is True
-assert r["response"]["num-tokens-revoked"] >= 1
-
-r = provider.audit_tokens(5)
-assert r["success"] is True
-audit_report        = r['response']
-as_consumer         = audit_report["as-consumer"]
-num_revoked_after   = 0
-
-for a in as_consumer:
-        if a['revoked'] is True:
-                num_revoked_after = num_revoked_after + 1
-
-assert num_revoked_before < num_revoked_after
-
-new_policy  = "*@iisc.ac.in can access * for 1 month"
-assert provider.set_policy(new_policy)['success'] is True
-
 # test token request without APIs
+
+r = provider.provider_access(email, 'consumer', "rbccps.org/9cf2c2382cf661fc20a4776345a3be7a143a109c/rs1/r1", 'resourcegroup', caps)
+assert r['success']     == True
+assert r['status_code'] == 200
+
 body = [
         {
-                "id"    : "rbccps.org/9cf2c2382cf661fc20a4776345a3be7a143a109c/rs1/r1",
+                "id"    : "rbccps.org/9cf2c2382cf661fc20a4776345a3be7a143a109c/rs1/r1/*",
         },
         {
-                "id"    : "rbccps.org/9cf2c2382cf661fc20a4776345a3be7a143a109c/rs1/r2"
+                "id"    : "rbccps.org/9cf2c2382cf661fc20a4776345a3be7a143a109c/rs1/r1/r2"
         }
 ]
 
@@ -263,11 +233,11 @@ assert r['status_code'] == 400
 
 body = [
         {
-                "id"    : "rbccps.org/9cf2c2382cf661fc20a4776345a3be7a143a109c/rs1/r1",
+                "id"    : "rbccps.org/9cf2c2382cf661fc20a4776345a3be7a143a109c/rs1/r1/*",
                 "apis"  : ["/ngsi-invalid"]
         },
         {
-                "id"    : "rbccps.org/9cf2c2382cf661fc20a4776345a3be7a143a109c/rs1/r2",
+                "id"    : "rbccps.org/9cf2c2382cf661fc20a4776345a3be7a143a109c/rs1/r1/r2",
                 "apis"  : ["/ngsi-invalid"]
         }
 ]
@@ -281,11 +251,11 @@ assert r['status_code'] == 400
 
 body = [
         {
-                "id"    : "rbccps.org/9cf2c2382cf661fc20a4776345a3be7a143a109c/rs1/r1",
+                "id"    : "rbccps.org/9cf2c2382cf661fc20a4776345a3be7a143a109c/rs1/r1/*",
                 "apis"  : ["/ngsi-ld/v1/temporal/entities"]
         },
         {
-                "id"    : "rbccps.org/9cf2c2382cf661fc20a4776345a3be7a143a109c/rs1/r2",
+                "id"    : "rbccps.org/9cf2c2382cf661fc20a4776345a3be7a143a109c/rs1/r1/r2",
                 "apis"  : ["/ngsi-ld/v1/temporal/entities"]
         }
 ]
@@ -295,11 +265,11 @@ access_token = r['response']
 
 assert r['success']     is True
 assert None             != access_token
-assert 60*60*24*30      == access_token['expires-in']
+assert 60*60*24*7       == access_token['expires-in']
 
 body = [
         {
-                "id"    : "rbccps.org/9cf2c2382cf661fc20a4776345a3be7a143a109c/rs1/r1",
+                "id"    : "rbccps.org/9cf2c2382cf661fc20a4776345a3be7a143a109c/rs1/r1/*",
                 "apis"  : ["/ngsi-ld/v1/temporal/entities"]
         },
         {
@@ -313,47 +283,46 @@ r = restricted_consumer.get_token(body)
 expect_failure(False)
 
 assert r['success']     is False
-assert r['status_code'] == 403
+assert r['status_code'] == 400
 
 # new api tests
 
-new_policy  = "*@iisc.ac.in can access * for 5 months"
-assert provider.set_policy(new_policy)['success'] is True
-
 body = [
         {
-            "id"    : "rbccps.org/9cf2c2382cf661fc20a4776345a3be7a143a109c/rs1/r1",
+            "id"    : "rbccps.org/9cf2c2382cf661fc20a4776345a3be7a143a109c/rs1/r1/item-0",
             "apis"  : ["/ngsi-ld/v1/temporal/entities"]
             },
         {
-            "id" : "rbccps.org/9cf2c2382cf661fc20a4776345a3be7a143a109c/rs2/r2",
+            "id" : "rbccps.org/9cf2c2382cf661fc20a4776345a3be7a143a109c/rs1/r1/item-1",
             "apis"  : ["/ngsi-ld/v1/temporal/entities"]
             }
         ]
 
 r = consumer.get_token(body)
 assert r['success']                     is True
-assert r['response']['expires-in']      == 60*60*24*30*5
+assert r['response']['expires-in']      == 60*60*24*7
 
 # test audit for multiple providers
 
-policy = "all can access abc.com/*"
-provider.set_policy(policy)
+r = provider.provider_access(email, 'consumer', "rbccps.org/9cf2c2382cf661fc20a4776345a3be7a143a109c/abc.com/r1", 'resourcegroup', caps)
+assert r['success']     == True
+assert r['status_code'] == 200
 
-policy = 'all can access example.com/test-providers'
-alt_provider.set_policy(policy)
+r = alt_provider.provider_access(email, 'consumer', "iisc.ac.in/2052f450ac2dde345335fb18b82e21da92e3388c/example.com/test-providers", 'resourcegroup', caps)
+assert r['success']     == True
+assert r['status_code'] == 200
 
 body = [
         {
-                "id"    : "iisc.ac.in/2052f450ac2dde345335fb18b82e21da92e3388c/example.com/test-providers",
+                "id"    : "iisc.ac.in/2052f450ac2dde345335fb18b82e21da92e3388c/example.com/test-providers/*",
                 "apis"  : ["/ngsi-ld/v1/temporal/entities"]
         },
         {
-                "id"    : "rbccps.org/9cf2c2382cf661fc20a4776345a3be7a143a109c/abc.com/ABC123",
+                "id"    : "rbccps.org/9cf2c2382cf661fc20a4776345a3be7a143a109c/abc.com/r1/ABC123",
                 "apis"  : ["/ngsi-ld/v1/temporal/entities"]
         },
         {
-                "id"    : "rbccps.org/9cf2c2382cf661fc20a4776345a3be7a143a109c/abc.com/abc-xyz",
+                "id"    : "rbccps.org/9cf2c2382cf661fc20a4776345a3be7a143a109c/abc.com/r1/abc-xyz",
                 "apis"  : ["/ngsi-ld/v1/temporal/entities"]
         }
 ]

--- a/test/test-tokens.py
+++ b/test/test-tokens.py
@@ -10,7 +10,7 @@ from init import resource_server
 
 from init import expect_failure
 
-from init import restricted_consumer
+from init import consumer
 
 # for registration and resetting roles
 from access import *
@@ -223,7 +223,7 @@ body = [
 ]
 
 expect_failure(True)
-r = restricted_consumer.get_token(body)
+r = consumer.get_token(body)
 expect_failure(False)
 
 assert r['success']     is False
@@ -243,7 +243,7 @@ body = [
 ]
 
 expect_failure(True)
-r = restricted_consumer.get_token(body)
+r = consumer.get_token(body)
 expect_failure(False)
 
 assert r['success']     is False
@@ -260,7 +260,7 @@ body = [
         }
 ]
 
-r = restricted_consumer.get_token(body)
+r = consumer.get_token(body)
 access_token = r['response']
 
 assert r['success']     is True
@@ -279,11 +279,11 @@ body = [
 ]
 
 expect_failure(True)
-r = restricted_consumer.get_token(body)
+r = consumer.get_token(body)
 expect_failure(False)
 
 assert r['success']     is False
-assert r['status_code'] == 400
+assert r['status_code'] == 403
 
 # new api tests
 

--- a/test/test_access.py
+++ b/test/test_access.py
@@ -4,12 +4,10 @@ from access import *
 from consent import role_reg
 import random
 import string
-
-init_provider()
+import pytest
 
 # use consumer certificate to register
 email   = "barun@iisc.ac.in"
-assert reset_role(email) == True
 org_id = add_organization("iisc.ac.in")
 
 ingester_id = 0 
@@ -17,13 +15,13 @@ consumer_id = 0
 onboarder_id = 0
 cat_id = ''
 
-# delete all old policies using acl/set API
-policy = "x can access x"
-r = untrusted.set_policy(policy)
-assert r['success'] is True
-
 # provider ID of abc.xyz@rbccps.org
 provider_id = 'rbccps.org/f3dad987e514af08a4ac46cf4a41bd1df645c8cc'
+
+@pytest.fixture(scope="session", autouse=True)
+def init():
+        init_provider("xyz.abc@rbccps.org")
+        assert reset_role(email) == True
 
 ##### consumer #####
 

--- a/test/test_access.py
+++ b/test/test_access.py
@@ -29,10 +29,11 @@ resource_group = ''.join(random.choice(string.ascii_lowercase) for _ in range(10
 resource_id = provider_id + '/rs.example.com/' + resource_group
 
 def test_consumer_no_rule_set():
-        # token request should fail
+        # token request should fail - not registered 
         body = {"id" : resource_id + "/someitem", "apis" : ["/ngsi-ld/v1/entities"] }
         r = consumer.get_token(body)
         assert r['success']     is False
+        assert r['status_code'] == 401
 
 def test_consumer_reg():
         r = role_reg(email, '9454234223', name , ["consumer"], None, csr)
@@ -161,6 +162,7 @@ def test_get_onboarder_token_fail():
         # onboarder token request should fail
         r = consumer.get_token(body)
         assert r['success']     is False
+        assert r['status_code'] == 403
 
 def test_reg_onboarder():
         r = role_reg(email, '9454234223', name , ["onboarder"], org_id)
@@ -195,6 +197,7 @@ def test_get_ingester_token_fail():
         # data ingester token request should fail
         r = consumer.get_token(body)
         assert r['success']     is False
+        assert r['status_code'] == 403
 
 def test_reg_ingester():
         r = role_reg(email, '9454234223', name , ["data ingester"], org_id)
@@ -278,6 +281,7 @@ def test_delete_onboarder_rule():
         # onboarder token request should fail
         r = consumer.get_token(token_body)
         assert r['success']     is False
+        assert r['status_code'] == 403
 
 def test_delete_ingester_temporal():
         global ingester_id, consumer_id
@@ -304,10 +308,12 @@ def test_delete_ingester_temporal():
         token_body = {"id" : diresource_id + "/someitem/someotheritem", "api" : "/iudx/v1/adapter" }
         r = consumer.get_token(token_body)
         assert r['success']     is False
+        assert r['status_code'] == 403
 
         token_body = {"id" : resource_id + "/something", "apis" : ["/ngsi-ld/v1/temporal/entities"] }
         r = consumer.get_token(token_body)
         assert r['success']     is False
+        assert r['status_code'] == 403
 
         body = [{"id": ingester_id}, {"id": consumer_id, "capabilities": ["temporal"]}]
         r = untrusted.delete_rule(body)
@@ -339,8 +345,10 @@ def test_delete_consumer_rule():
         token_body = {"id" : resource_id + "/someitem", "apis" : apis }
         r = consumer.get_token(token_body)
         assert r['success']     is False
+        assert r['status_code'] == 403
 
         token_body = {"id" : resource_id + "/someitem", "apis" : ["/ngsi-ld/v1/subscription"] }
         r = consumer.get_token(token_body)
         assert r['success']     is False
+        assert r['status_code'] == 403
 

--- a/test/test_tokens.py
+++ b/test/test_tokens.py
@@ -311,7 +311,7 @@ def test_token_api():
         expect_failure(False)
 
         assert r['success']     is False
-        assert r['status_code'] == 400
+        assert r['status_code'] == 403
 
         # new api tests
 


### PR DESCRIPTION
* Changes to GET /provider/access to improve performance (slightly)
* Added indexes to foreign key relations in consent schema + removed indexes on primary keys
* Removed compression middleware - NGINX does it

* 8891005, 9ac3489, eab35b2 deal with moving from `policy` table to `consent.access` for access APIs. 
* 8891005
    - Parse policy text and create JSON aperture policy; store in DB in consent.access.policy_json column
    - Use CTE to aggregate all the JSON policies and push into `policy` table after Create/Update/Delete of access policies
    - Update schema to include `policy_json` col
    - Added `scripts/add_json_policy_to_db.js` to convert existing policies to JSON
* 9ac3489
    - Stop using `policy` table
    - Filter based on resourcegroup ID/catalogue + provider + consumer/onboarder/ingester to get at most 1 JSON aperture policy to evaluate when issuing token
    - Remove deprecated groups functionality from token API + other dead code
    - Update tests
* eab35b2
    - Clean up code + use async queries in token API
    - Update tests
