### PR TITLE
Cleanup:remove old cert flows, add created_at,updated_at to capabilities table, 

### DIFF
--- a/consent_schema.sql
+++ b/consent_schema.sql
@@ -106,6 +106,8 @@ CREATE TABLE consent.capability (
 	id			integer GENERATED ALWAYS AS IDENTITY		PRIMARY KEY,
 	access_id		integer NOT NULL REFERENCES consent.access(id)	ON DELETE CASCADE,
 	capability		consent.capability_enum				NOT NULL,
+	created_at		timestamp without time zone			NOT NULL,
+	updated_at		timestamp without time zone			NOT NULL,
 	UNIQUE (access_id, capability)
 );
 

--- a/main.js
+++ b/main.js
@@ -2718,11 +2718,11 @@ app.post("/auth/v[1-2]/provider/access", async (req, res) => {
 		if (! res_type || ! RESOURCE_ITEM_TYPES.includes(res_type))
 			return END_ERROR (res, 400, "Invalid data (item-type)");
 
-		// resource group must have 3 slashes
-		if ((resource.match(/\//g) || []).length !== 3)
+		if (! is_string_safe(resource, "_") || resource.indexOf("..") >= 0)
 			return END_ERROR (res, 400, "Invalid data (item-id)");
 
-		if (! is_string_safe(resource, "_") || resource.indexOf("..") >= 0)
+		// resource group must have 3 slashes
+		if ((resource.match(/\//g) || []).length !== 3)
 			return END_ERROR (res, 400, "Invalid data (item-id)");
 
 		if (! resource.startsWith(provider_id_hash))

--- a/main.js
+++ b/main.js
@@ -1036,20 +1036,6 @@ function basic_security_check (req, res, next)
 			}
 		}
 
-		if (user_notice.untrusted)
-		{
-			res.locals.untrusted = true;
-		}
-
-		if (user_notice["delegated-by"])
-		{
-			return END_ERROR (
-				res, 403,
-					"Delegated certificates cannot"	+
-					" be used to call auth/marketplace APIs"
-			);
-		}
-
 		const	cert_class		= user_notice["class"];
 		let	integer_cert_class	= 0;
 
@@ -1119,70 +1105,6 @@ function basic_security_check (req, res, next)
 							.subject
 							.emailAddress
 							.toLowerCase();
-
-			if (user_notice["can-access"])
-			{
-				res.locals.can_access_regex	= [];
-
-				const can_access_regex		= user_notice["can-access"]
-									.split(";");
-				let regex_number		= 0;
-
-				for (const r of can_access_regex)
-				{
-					++regex_number;
-
-					const regex = r.trim();
-
-					if (regex === "")
-						continue;
-
-					/*
-						allow '^' '*' and '$' characters
-						but not unsafe RegEx
-					*/
-
-					if (! is_string_safe(regex,"^*$"))
-					{
-						const error_response = {
-							"message"	: "Unsafe 'can-access' RegEx in certificate",
-							"invalid-input"	: "RegEx no. " + regex_number,
-						};
-
-						return END_ERROR (
-							res, 400,
-								error_response
-						);
-					}
-
-					/*
-						We don't support ".", replace:
-							"."	with	"\."
-							"*"	with	".*"
-					*/
-
-					const final_regex = regex
-								.replace(/\./g,"\\.")
-								.replace(/\*/g,".*");
-
-					if (! safe_regex(final_regex))
-					{
-						const error_response = {
-							"message"	: "Unsafe 'can-access' RegEx in certificate",
-							"invalid-input"	: "RegEx no. " + regex_number,
-						};
-
-						return END_ERROR (
-							res, 400,
-								error_response
-						);
-					}
-
-					res.locals.can_access_regex.push (
-						new RegExp(final_regex)
-					);
-				}
-			}
 
 			Object.freeze(res.locals);
 			Object.freeze(res.locals.body);
@@ -3003,9 +2925,10 @@ app.post("/auth/v[1-2]/provider/access", async (req, res) => {
 			for (const cap of req_capability)
 			{
 				const result = await pool.query (
-					"INSERT INTO consent.capability "		+
-					" (access_id, capability) VALUES"		+
-					" ($1::integer, $2::consent.capability_enum)",
+					"INSERT INTO consent.capability "			+
+					" (access_id, capability, created_at, updated_at)"	+ 
+					" VALUES ($1::integer, $2::consent.capability_enum," 	+
+					" NOW(), NOW())",
 					[ access_id, cap ]);
 			}
 		}

--- a/test/test-certificates.py
+++ b/test/test-certificates.py
@@ -24,33 +24,6 @@ assert r["success"] is True
 assert r["response"]["certificate-class"] == 3
 assert r["response"]["id"] == "arun.babu@rbccps.org"
 
-# delegated certificate cannot call any Auth API
-
-expect_failure(True)
-r = delegate.certificate_info()
-expect_failure(False)
-
-assert r["success"] is False
-assert r['status_code'] == 403
-
-# delegated certificate cannot call any Marketplace API
-
-expect_failure(True)
-#r = delegate.topup(100)
-expect_failure(False)
-
-assert r["success"] is False
-assert r['status_code'] == 403
-
-# untrusted certificates cannot call any Marketplace API
-
-expect_failure(True)
-#r = untrusted.topup(100)
-expect_failure(False)
-
-assert r["success"] is False
-assert r['status_code'] == 403
-
 r = example_dot_com.certificate_info()
 assert r["success"] is True
 assert r["response"]["certificate-class"] == 1


### PR DESCRIPTION
- Certificates used to have 'delegated-by' and 'can-access' properties before. Removed from main.js and from test/test-certificates.py
- Updated capability table to have created_at, updated_at
- In /provider/access, check validity of string before running regex on it