### PR TITLE
Fix consumer duplicates for POST access API

### DIFF
--- a/main.js
+++ b/main.js
@@ -2566,38 +2566,21 @@ app.post("/auth/v[1-2]/provider/access", async (req, res) => {
 
     /* check for duplicates in the object array */
     for (const i of to_add) {
-      if (i.accesser_role === "onboarder" && accesser_role === "onboarder") {
-        if (i.accesser_email === accesser_email) {
-          err.message = "Invalid data (duplicate)";
-          return END_ERROR(res, 400, err);
-        }
-      } else if (
-        i.accesser_role === "data ingester" &&
-        accesser_role === "data ingester"
+      if (
+        i.accesser_email === accesser_email &&
+        i.accesser_role === accesser_role
       ) {
-        if (
-          i.accesser_email === accesser_email &&
-          i.resource === resource &&
-          i.res_type === res_type
-        ) {
-          err.message = "Invalid data (duplicate)";
-          return END_ERROR(res, 400, err);
-        }
-      } else if (
-        i.accesser_role === "consumer" &&
-        accesser_role === "consumer"
-      ) {
-        if (
-          i.accesser_email === accesser_email &&
-          i.resource === resource &&
-          i.res_type === res_type
-        ) {
-          let duplicate = intersect(req_capability, i.req_capability);
-
-          if (duplicate.length !== 0) {
+        switch (accesser_role) {
+          case "onboarder":
+          case "delegate":
             err.message = "Invalid data (duplicate)";
             return END_ERROR(res, 400, err);
-          }
+          case "consumer":
+          case "data ingester":
+            if (i.resource === resource && i.res_type === res_type) {
+              err.message = "Invalid data (duplicate)";
+              return END_ERROR(res, 400, err);
+            }
         }
       }
     }

--- a/main.js
+++ b/main.js
@@ -226,37 +226,6 @@ function is_valid_token(token, user = null) {
   return true;
 }
 
-function is_valid_tokenhash(token_hash) {
-  if (!is_string_safe(token_hash)) return false;
-
-  if (token_hash.length < MIN_TOKEN_HASH_LEN) return false;
-
-  if (token_hash.length > MAX_TOKEN_HASH_LEN) return false;
-
-  const hex_regex = new RegExp(/^[a-f0-9]+$/);
-
-  if (!hex_regex.test(token_hash)) return false;
-
-  return true;
-}
-
-function is_valid_servertoken(server_token, hostname) {
-  if (!is_string_safe(server_token)) return false;
-
-  const split = server_token.split("/");
-
-  if (split.length !== 2) return false;
-
-  const issued_to = split[0];
-  const random_hex = split[1];
-
-  if (issued_to !== hostname) return false;
-
-  if (random_hex.length !== TOKEN_LEN_HEX) return false;
-
-  return true;
-}
-
 function sha1(string) {
   return crypto.createHash("sha1").update(string).digest("hex");
 }
@@ -319,7 +288,6 @@ function END_ERROR(res, http_status, error, exception = null) {
   res.setHeader("Connection", "close");
 
   const response = {};
-  console.log(exception);
 
   if (typeof error === "string") response.error = { message: error };
   else {

--- a/test/test_access-delegate.py
+++ b/test/test_access-delegate.py
@@ -145,7 +145,7 @@ def test_provider_update_rule_set_by_delegate():
         # provider can update consumer rule set by delegate
 
         req = {"user_email": email, "user_role":'consumer', "item_id":resource_id, "item_type":"resourcegroup"}
-        req["capabilities"] = ['complex'];
+        req["capabilities"] = ['complex', 'subscription'];
         r = untrusted.provider_access([req], 'abc.xyz@rbccps.org')
         assert r['success']     == True
         assert r['status_code'] == 200
@@ -216,6 +216,12 @@ def test_delegate_set_delegate_rule():
         assert r['success']     == False
         assert r['status_code'] == 403
 
+        req1 = {"user_email": email, "user_role":'data ingester', "item_id":resource_id, "item_type":"resourcegroup"}
+        req2 = {"user_email": email, "user_role":'delegate'}
+        r = alt_provider.provider_access([req1, req2], 'abc.xyz@rbccps.org')
+        assert r['success']     == False
+        assert r['status_code'] == 403
+
 def test_delegate_get_all_rules():
         # test getting all access rules
         global consumer_id, onboarder_id, ingester_id, delegate_id, provider_set_consumer_id
@@ -234,7 +240,7 @@ def test_delegate_get_all_rules():
                 if r['email'] == email and r['role'] == 'consumer' and resource_id == r['item']['cat_id']:
                         consumer_id = r['id']
                         assert set(r['capabilities']).issubset(set(['temporal', 'subscription', 'complex']))
-                        assert len(r['capabilities']) <= 3 and len(r['capabilities']) >= 1
+                        assert len(r['capabilities']) == 3
                         check_con = True
                 if r['email'] == email and r['role'] == 'consumer' and pr_resource_id == r['item']['cat_id']:
                         provider_set_consumer_id = r['id']


### PR DESCRIPTION
- Previously, duplicates were allowed in the POST access API for consumer rules, so long as the capabilities differed (hence updating the rule in the same request)
- This caused bugs as new rows were created for each policy, instead of only updating the capabilities table. `expiry_time` makes things more complicated. 
- Hence, if duplicate consumer policies (same `user_email`, `user_role`, `item_id` and `item_type`) exists, now throw error.
- Additionally, duplicate delegate policies were not checked, checking now

### Misc
- Update tests to account for above changes + add tests for POST access API
- Remove unused functions from main.js